### PR TITLE
Add barrierDismissible to cupertino dialog.

### DIFF
--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -40,7 +40,9 @@ bool isCupertino(BuildContext context) {
 Future<T> showPlatformDialog<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
+  @Deprecated("Use barrierDismissible instead")
   bool androidBarrierDismissible = true,
+  bool barrierDismissible = true,
   RouteSettings routeSettings,
   bool useRootNavigator = true,
 }) {
@@ -48,7 +50,7 @@ Future<T> showPlatformDialog<T>({
     return showDialog<T>(
       context: context,
       builder: builder,
-      barrierDismissible: androidBarrierDismissible,
+      barrierDismissible: androidBarrierDismissible || barrierDismissible,
       routeSettings: routeSettings,
       useRootNavigator: useRootNavigator,
     );
@@ -58,6 +60,7 @@ Future<T> showPlatformDialog<T>({
       builder: builder,
       routeSettings: routeSettings,
       useRootNavigator: useRootNavigator,
+      barrierDismissible: barrierDismissible,
     );
   }
 }


### PR DESCRIPTION
This is available and works for Cupertino dialog as well.

This works (i.e. barrier dismiss works):
```
showCupertinoDialog(
    barrierDismissible: true,
    context: context,
    builder: (context) {
      return Column(
        mainAxisSize: MainAxisSize.min,
        mainAxisAlignment: MainAxisAlignment.center,
        children: [
          Text(
            "RESERVATION DETAILS",
          ),
        ],
      );
    });

```