### PR TITLE
Add property `hint` to PlatformTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.72.0] - December 03, 2020
+
+#### (Flutter version support: v1.22.0 - v1.22.4)
+
+- Adds `materialBuilder` and `cupertinoBuilder` as alternatives to `material` and `cupertino` on `PlatformTabScaffold` so that the widgets can change properties on tab index change. see example/lib/tabbed/dynamicTabbedPage.dart.
+- Adds new polatform icons, thumb up and down and fix the star icon (thanks DFelten)
+
 ## [0.71.0] - November 08, 2020
 
 #### (Flutter version support: v1.22.0 - v1.22.3)

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ More more detailed example look at:
 
 - [Basic Example](https://github.com/stryder-dev/flutter_platform_widgets/blob/master/example/lib/tabbed/basicTabbedPage.dart)
 - [Sliver Example](https://github.com/stryder-dev/flutter_platform_widgets/blob/master/example/lib/tabbed/sliverTabbedPage.dart)
+- [Dynamic Example](https://github.com/stryder-dev/flutter_platform_widgets/blob/master/example/lib/tabbed/dynamicTabbedPage.dart)
 
 > Note that the use of `iosContentPadding = true` is only required if the content is being obstruced behind the appBar. `iosContentBottomPadding` is used if the content needs to be above the navBar and not go behind it. This will not have the translucent effect for iOS when these are set to `true`. If that is desirable, then the scrolling and content alignment need to be managed yourself.
 
@@ -314,6 +315,8 @@ return PlatformTabScaffold(
 ```
 
 > Both the material and cupertino builders are optional. If not provided the `SizedBox.shrink()` placeholder widget will be returned.
+> `material` can be replaced with `materialBuilder` for dynamic rendering on index change
+> `cupertino` can be replaced with `cupertinoBuilder` for dynamic rendering on index change
 
 ## PlatformAppBar
 
@@ -617,7 +620,7 @@ Special thanks for everyone that have contributed to this project...
 | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | [![](https://avatars1.githubusercontent.com/u/4413519?s=40&v=4)](https://github.com/aqwert)           | [Lance Johnstone](https://github.com/aqwert)                  | [![](images/linkedIn_img.png)](https://www.linkedin.com/in/lancejohnstone/)                           |
 | [![](https://avatars2.githubusercontent.com/u/58397?s=40&v=4)](https://github.com/stefanrusek)        | [Stefan Rusek](https://github.com/stefanrusek)                |
-| [![](https://ui-avatars.com/api/?name=Mark+Lavercombe&size=40)](https://github.com/stefanrusek)       | [Mark Lavercombe](https://github.com/mlava)                   |
+| [![](https://ui-avatars.com/api/?name=Mark+Lavercombe&size=40)](https://github.com/mlava)             | [Mark Lavercombe](https://github.com/mlava)                   |
 | [![](https://avatars3.githubusercontent.com/u/15651?s=40&v=4)](https://github.com/fredgrott)          | [Fred Grott](https://github.com/fredgrott)                    | [![](images/linkedIn_img.png)](https://www.linkedin.com/in/fredgrottstartupfluttermobileappdesigner/) |
 | [![](https://avatars0.githubusercontent.com/u/26111180?s=40&v=4)](https://github.com/fbernutz)        | [Felizia Bernutz](https://github.com/fbernutz)                |
 | [![](https://avatars3.githubusercontent.com/u/227856?s=40&v=4)](https://github.com/eyecreate)         | [eyecreate](https://github.com/eyecreate)                     |
@@ -626,7 +629,7 @@ Special thanks for everyone that have contributed to this project...
 | [![](https://avatars2.githubusercontent.com/u/10937624?s=40&v=4)](https://github.com/GillesMontyne)   | [Gilles Montyne](https://github.com/GillesMontyne)            |
 | [![](https://avatars2.githubusercontent.com/u/1435744?s=40&v=4)](https://github.com/sck-v)            | [Ivan Kryak](https://github.com/sck-v)                        |
 | [![](https://ui-avatars.com/api/?name=Morris+Haid&size=40)](https://github.com/mhaid)                 | [Morris Haid](https://github.com/mhaid)                       |
-| [![](https://ui-avatars.com/api/?name=Joscha+Eckert&size=40)](https://github.com/josxhad)             | [Joscha Eckert](https://github.com/josxha)                    |
+| [![](https://ui-avatars.com/api/?name=Joscha+Eckert&size=40)](https://github.com/josxha)              | [Joscha Eckert](https://github.com/josxha)                    |
 | [![](https://avatars1.githubusercontent.com/u/1281777?s=40&v=4)](https://github.com/furkantektas)     | [Furkan Tektas](https://github.com/furkantektas)              |
 | [![](https://avatars3.githubusercontent.com/u/2480235?s=40&v=4)](https://github.com/dabenzel)         | [benzel](https://github.com/dabenzel)                         |
 | [![](https://avatars1.githubusercontent.com/u/1858194?s=40&v=4)](https://github.com/cmengler)         | [Christian Mengler](https://github.com/cmengler)              |
@@ -636,7 +639,8 @@ Special thanks for everyone that have contributed to this project...
 | [![](https://avatars1.githubusercontent.com/u/11311182?s=40&v=4)](https://github.com/OnyekachiSamuel) | [Ezeoke Onyekachi Samuel](https://github.com/OnyekachiSamuel) |
 | [![](https://avatars0.githubusercontent.com/u/7694636?s=40&v=4)](https://github.com/KoningJasper)     | [Jasper Koning](https://github.com/KoningJasper)              |
 | [![](https://ui-avatars.com/api/?name=AlexIver&size=40)](https://github.com/AlexIver)                 | [AlexIver](https://github.com/AlexIver)                       |
-| [![](https://ui-avatars.com/api/?name=in74mz&size=40)](https://github.com/in74mz)                     | [AlexIver](https://github.com/**in74mz**)                     |
+| [![](https://avatars1.githubusercontent.com/u/35923031?s=40&v=4)](https://github.com/in74mz)          | [in74mz](https://github.com/in74mz)                           |
+| [![](https://avatars0.githubusercontent.com/u/1169185?s=40&v=4)](https://github.com/DFelten)          | [Daniel Felten](https://github.com/DFelten)                    |
 
 # Acknowledgements
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -223,18 +223,18 @@ class LandingPageState extends State<LandingPage> {
               padding: const EdgeInsets.all(8.0),
               child: PlatformTextField(
                 controller: textControlller,
-                hintText: null,
+                hint: null,
               ),
             ),
             Container(
               padding: const EdgeInsets.all(8.0),
               height: 100,
               child: PlatformTextField(
+<<<<<<< HEAD
                 hintText: 'And another one',
-                expands: true,
-                maxLines: null,
+=======
+                hint: 'And another one',
                 controller: textMultiLineControlller,
-              ),
               PlatformSlider(
                 value: sliderValue,
                 onChanged: (double newValue) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -235,14 +235,14 @@ class LandingPageState extends State<LandingPage> {
               padding: const EdgeInsets.all(8.0),
               child: PlatformTextField(
                 controller: textControlller,
-                hint: null,
+                hintText: null,
               ),
             ),
             Container(
               padding: const EdgeInsets.all(8.0),
               height: 100,
               child: PlatformTextField(
-                hint: 'And another one',
+                hintText: 'And another one',
                 expands: true,
                 maxLines: null,
                 controller: textMultiLineControlller,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -235,12 +235,14 @@ class LandingPageState extends State<LandingPage> {
               padding: const EdgeInsets.all(8.0),
               child: PlatformTextField(
                 controller: textControlller,
+                hint: null,
               ),
             ),
             Container(
               padding: const EdgeInsets.all(8.0),
               height: 100,
               child: PlatformTextField(
+                hint: 'And another one',
                 expands: true,
                 maxLines: null,
                 controller: textMultiLineControlller,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,7 @@ import 'iconPage.dart';
 import 'listViewHeaderPage.dart';
 import 'listViewPage.dart';
 import 'tabbed/basicTabbedPage.dart';
+import 'tabbed/dynamicTabbedPage.dart';
 import 'tabbed/originalTabbedPage.dart';
 import 'tabbed/sliverTabbedPage.dart';
 import 'tabbedPage.dart';
@@ -149,7 +150,7 @@ class LandingPageState extends State<LandingPage> {
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(
-      iosContentPadding: true,
+      //iosContentPadding: true,
       appBar: PlatformAppBar(
         title: Text('Flutter Platform Widgets'),
         trailingActions: <Widget>[
@@ -160,67 +161,54 @@ class LandingPageState extends State<LandingPage> {
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                  'Primary concept of this package is to use the same widgets to create iOS (Cupertino) or Android (Material) looking apps rather than needing to discover what widgets to use.'),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                  'This approach is best when both iOS and Android apps follow the same design in layout and navigation, but need to look as close to native styling as possible.'),
-            ),
-            Divider(),
-            PlatformButton(
-              child: PlatformText('Toggle Dark / Light mode'),
-              onPressed: _toggleBrightness,
-            ),
-            Divider(),
-            SectionHeader(title: '1. Change Platform'),
-            PlatformButton(
-              child: PlatformText('Switch Platform'),
-              onPressed: () => _switchPlatform(context),
-            ),
-            PlatformWidget(
-              material: (_, __) => Text('Currently showing Material'),
-              cupertino: (_, __) => Text('Currently showing Cupertino'),
-            ),
-            Text('Scaffold: PlatformScaffold'),
-            Text('AppBar: PlatformAppBar'),
-            Divider(),
-            SectionHeader(title: '2. Basic Widgets'),
-            PlatformText(
-              'PlatformText will uppercase for Material only',
-              textAlign: TextAlign.center,
-            ),
-            PlatformButton(
-              child: PlatformText('PlatformButton'),
-              onPressed: () {},
-            ),
-            PlatformButton(
-              child: PlatformText('Platform Flat/Filled Button'),
-              onPressed: () {},
-              materialFlat: (_, __) => MaterialFlatButtonData(),
-              cupertinoFilled: (_, __) => CupertinoFilledButtonData(),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: PlatformIconButton(
-                materialIcon: Icon(Icons.home),
-                cupertinoIcon: Icon(CupertinoIcons.home),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                    'Primary concept of this package is to use the same widgets to create iOS (Cupertino) or Android (Material) looking apps rather than needing to discover what widgets to use.'),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                    'This approach is best when both iOS and Android apps follow the same design in layout and navigation, but need to look as close to native styling as possible.'),
+              ),
+              Divider(),
+              PlatformButton(
+                child: PlatformText('Toggle Dark / Light mode'),
+                onPressed: _toggleBrightness,
+              ),
+              Divider(),
+              SectionHeader(title: '1. Change Platform'),
+              PlatformButton(
+                child: PlatformText('Switch Platform'),
+                onPressed: () => _switchPlatform(context),
+              ),
+              PlatformWidget(
+                material: (_, __) => Text('Currently showing Material'),
+                cupertino: (_, __) => Text('Currently showing Cupertino'),
+              ),
+              Text('Scaffold: PlatformScaffold'),
+              Text('AppBar: PlatformAppBar'),
+              Divider(),
+              SectionHeader(title: '2. Basic Widgets'),
+              PlatformText(
+                'PlatformText will uppercase for Material only',
+                textAlign: TextAlign.center,
+              ),
+              PlatformButton(
+                child: PlatformText('PlatformButton'),
                 onPressed: () {},
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: PlatformSwitch(
-                value: switchValue,
-                onChanged: (bool value) => setState(() => switchValue = value),
+              PlatformButton(
+                child: PlatformText('Platform Flat/Filled Button'),
+                onPressed: () {},
+                materialFlat: (_, __) => MaterialFlatButtonData(),
+                cupertinoFilled: (_, __) => CupertinoFilledButtonData(),
               ),
             ),
             PlatformSlider(
@@ -247,85 +235,112 @@ class LandingPageState extends State<LandingPage> {
                 maxLines: null,
                 controller: textMultiLineControlller,
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: PlatformCircularProgressIndicator(
-                cupertino: (_, __) => CupertinoProgressIndicatorData(),
-                material: (_, __) => MaterialProgressIndicatorData(),
+              PlatformSlider(
+                value: sliderValue,
+                onChanged: (double newValue) {
+                  setState(() {
+                    sliderValue = newValue;
+                  });
+                },
               ),
-            ),
-            Divider(),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: PlatformWidgetBuilder(
-                cupertino: (_, child, __) => GestureDetector(
-                  child: child,
-                  onTap: () => print('Cupertino PlatformWidgetBuilder'),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: PlatformTextField(
+                  controller: textControlller,
                 ),
-                material: (_, child, __) => GestureDetector(
-                  child: child,
-                  onTap: () => print('Material PlatformWidgetBuilder'),
+              ),
+              Container(
+                padding: const EdgeInsets.all(8.0),
+                height: 100,
+                child: PlatformTextField(
+                  expands: true,
+                  maxLines: null,
+                  controller: textMultiLineControlller,
                 ),
-                child: Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Colors.grey,
-                    borderRadius: BorderRadius.circular(20),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: PlatformCircularProgressIndicator(
+                  cupertino: (_, __) => CupertinoProgressIndicatorData(),
+                  material: (_, __) => MaterialProgressIndicatorData(),
+                ),
+              ),
+              Divider(),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: PlatformWidgetBuilder(
+                  cupertino: (_, child, __) => GestureDetector(
+                    child: child,
+                    onTap: () => print('Cupertino PlatformWidgetBuilder'),
                   ),
-                  child: PlatformText('Platform Widget Builder'),
+                  material: (_, child, __) => GestureDetector(
+                    child: child,
+                    onTap: () => print('Material PlatformWidgetBuilder'),
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.grey,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: PlatformText('Platform Widget Builder'),
+                  ),
                 ),
               ),
-            ),
-            Divider(),
-            SectionHeader(title: '3. Dialogs'),
-            PlatformButton(
-              child: PlatformText('Show Dialog'),
-              onPressed: () => _showExampleDialog(),
-            ),
-            Divider(),
-            SectionHeader(title: '4. Popup/Sheet'),
-            PlatformButton(
-              child: PlatformText('Show Popup/Sheet'),
-              onPressed: () => _showPopupSheet(),
-            ),
-            Divider(),
-            SectionHeader(title: '5. Navigation'),
-            PlatformButton(
-              child: PlatformText('Open Tabbed Page'),
-              onPressed: () => _openPage((_) => TabbedPage()),
-            ),
-            PlatformButton(
-              child: PlatformText('Open Basic Tabbed Page'),
-              onPressed: () => _openPage((_) => BasicTabbedPage()),
-            ),
-            PlatformButton(
-              child: PlatformText('Open Sliver Tabbed Page'),
-              onPressed: () => _openPage((_) => SliverTabbedPage()),
-            ),
-            PlatformButton(
-              child: PlatformText('Open Original Tabbed Page'),
-              onPressed: () => _openPage((_) => OriginalTabbedPage()),
-            ),
-            Divider(),
-            SectionHeader(title: '6. Icons'),
-            PlatformButton(
-              child: PlatformText('Open Icons Page'),
-              onPressed: () => _openPage((_) => IconsPage()),
-            ),
-            Divider(),
-            SectionHeader(title: '7. Advanced'),
-            PlatformButton(
-              child: PlatformText('Page with ListView'),
-              onPressed: () => _openPage((_) => ListViewPage()),
-            ),
-            PlatformWidget(
-              cupertino: (_, __) => PlatformButton(
-                child: PlatformText('iOS Page with Colored Header'),
-                onPressed: () => _openPage((_) => ListViewHeaderPage()),
+              Divider(),
+              SectionHeader(title: '3. Dialogs'),
+              PlatformButton(
+                child: PlatformText('Show Dialog'),
+                onPressed: () => _showExampleDialog(),
               ),
-            ),
-          ],
+              Divider(),
+              SectionHeader(title: '4. Popup/Sheet'),
+              PlatformButton(
+                child: PlatformText('Show Popup/Sheet'),
+                onPressed: () => _showPopupSheet(),
+              ),
+              Divider(),
+              SectionHeader(title: '5. Navigation'),
+              PlatformButton(
+                child: PlatformText('Open Tabbed Page'),
+                onPressed: () => _openPage((_) => TabbedPage()),
+              ),
+              PlatformButton(
+                child: PlatformText('Open Basic Tabbed Page'),
+                onPressed: () => _openPage((_) => BasicTabbedPage()),
+              ),
+              PlatformButton(
+                child: PlatformText('Open Sliver Tabbed Page'),
+                onPressed: () => _openPage((_) => SliverTabbedPage()),
+              ),
+              PlatformButton(
+                child: PlatformText('Open Original Tabbed Page'),
+                onPressed: () => _openPage((_) => OriginalTabbedPage()),
+              ),
+              PlatformButton(
+                child: PlatformText('Open Dynamic Tabbed Page'),
+                onPressed: () => _openPage((_) => DynamicTabbedPage()),
+              ),
+              Divider(),
+              SectionHeader(title: '6. Icons'),
+              PlatformButton(
+                child: PlatformText('Open Icons Page'),
+                onPressed: () => _openPage((_) => IconsPage()),
+              ),
+              Divider(),
+              SectionHeader(title: '7. Advanced'),
+              PlatformButton(
+                child: PlatformText('Page with ListView'),
+                onPressed: () => _openPage((_) => ListViewPage()),
+              ),
+              PlatformWidget(
+                cupertino: (_, __) => PlatformButton(
+                  child: PlatformText('iOS Page with Colored Header'),
+                  onPressed: () => _openPage((_) => ListViewHeaderPage()),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/example/lib/tabbed/dynamicTabbedPage.dart
+++ b/example/lib/tabbed/dynamicTabbedPage.dart
@@ -1,0 +1,92 @@
+import 'package:example/tabbed/views/content_view.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+
+class DynamicTabbedPage extends StatefulWidget {
+  @override
+  _DynamicTabbedPageState createState() => _DynamicTabbedPageState();
+}
+
+class _DynamicTabbedPageState extends State<DynamicTabbedPage> {
+  static final titles = ['One', 'Two', 'Three'];
+  final icons = (BuildContext context) => [
+        Icon(context.platformIcons.batteryFull),
+        Icon(context.platformIcons.folder),
+        Icon(context.platformIcons.shoppingCart),
+      ];
+  final colors = [
+    Colors.amber,
+    Colors.cyan,
+    Colors.lime,
+  ];
+  List<BottomNavigationBarItem> Function(BuildContext) items;
+
+  // This needs to be captured here in a stateful widget
+  PlatformTabController tabController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // If you want further control of the tabs have one of these
+    if (tabController == null) {
+      tabController = PlatformTabController(
+        initialIndex: 1,
+      );
+    }
+
+    items = (BuildContext context) => [
+          BottomNavigationBarItem(
+            label: titles[0],
+            icon: icons(context)[0],
+            activeIcon: Icon(icons(context)[0].icon, color: colors[0]),
+          ),
+          BottomNavigationBarItem(
+            label: titles[1],
+            icon: icons(context)[1],
+            activeIcon: Icon(icons(context)[1].icon, color: colors[1]),
+          ),
+          BottomNavigationBarItem(
+            label: titles[2],
+            icon: icons(context)[2],
+            activeIcon: Icon(icons(context)[2].icon, color: colors[2]),
+          ),
+        ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformTabScaffold(
+      iosContentPadding: true,
+      tabController: tabController,
+      appBarBuilder: (_, index) => PlatformAppBar(
+        title: Text('Page Title'),
+        backgroundColor: colors[index],
+        trailingActions: <Widget>[
+          PlatformIconButton(
+            padding: EdgeInsets.zero,
+            icon: Icon(context.platformIcons.share),
+            onPressed: () {},
+          ),
+        ],
+        cupertino: (_, __) => CupertinoNavigationBarData(
+          title: Text('${titles[index]}'),
+        ),
+      ),
+      bodyBuilder: (context, index) => ContentView(index),
+      items: items(context),
+      materialBuilder: (context, __, index) => MaterialTabScaffoldData(
+        floatingActionButton: FloatingActionButton(
+          child: icons(context)[index],
+          backgroundColor: colors[index],
+          onPressed: () {},
+        ),
+      ),
+      cupertinoBuilder: (_, __, index) => CupertinoTabScaffoldData(
+        backgroundColor: colors[index],
+      ),
+    );
+  }
+}

--- a/lib/src/platform_alert_dialog.dart
+++ b/lib/src/platform_alert_dialog.dart
@@ -96,8 +96,8 @@ class PlatformAlertDialog
   final Widget content;
   final Widget title;
 
-  final PlatformBuilder2<MaterialAlertDialogData> material;
-  final PlatformBuilder2<CupertinoAlertDialogData> cupertino;
+  final PlatformBuilder<MaterialAlertDialogData> material;
+  final PlatformBuilder<CupertinoAlertDialogData> cupertino;
 
   PlatformAlertDialog({
     Key key,

--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -389,10 +389,10 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
   final Map<Type, Action<Intent>> actions;
   final InitialRouteListFactory onGenerateInitialRoutes;
 
-  final PlatformBuilder2<MaterialAppData> material;
-  final PlatformBuilder2<CupertinoAppData> cupertino;
-  final PlatformBuilder2<MaterialAppRouterData> materialRouter;
-  final PlatformBuilder2<CupertinoAppRouterData> cupertinoRouter;
+  final PlatformBuilder<MaterialAppData> material;
+  final PlatformBuilder<CupertinoAppData> cupertino;
+  final PlatformBuilder<MaterialAppRouterData> materialRouter;
+  final PlatformBuilder<CupertinoAppRouterData> cupertinoRouter;
 
   /// {@macro flutter.widgets.widgetsApp.routeInformationProvider}
   final RouteInformationProvider routeInformationProvider;
@@ -466,8 +466,8 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
     this.debugShowCheckedModeBanner,
     this.shortcuts,
     this.actions,
-    PlatformBuilder2<MaterialAppRouterData> material,
-    PlatformBuilder2<CupertinoAppRouterData> cupertino,
+    PlatformBuilder<MaterialAppRouterData> material,
+    PlatformBuilder<CupertinoAppRouterData> cupertino,
   })  : navigatorObservers = null,
         navigatorKey = null,
         onGenerateRoute = null,

--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -135,8 +135,8 @@ class PlatformAppBar
   final List<Widget> trailingActions;
   final bool automaticallyImplyLeading;
 
-  final PlatformBuilder2<MaterialAppBarData> material;
-  final PlatformBuilder2<CupertinoNavigationBarData> cupertino;
+  final PlatformBuilder<MaterialAppBarData> material;
+  final PlatformBuilder<CupertinoNavigationBarData> cupertino;
 
   PlatformAppBar({
     Key key,

--- a/lib/src/platform_button.dart
+++ b/lib/src/platform_button.dart
@@ -231,10 +231,10 @@ class PlatformButton
   final EdgeInsetsGeometry padding;
   final Color disabledColor;
 
-  final PlatformBuilder2<MaterialRaisedButtonData> material;
-  final PlatformBuilder2<MaterialFlatButtonData> materialFlat;
-  final PlatformBuilder2<CupertinoButtonData> cupertino;
-  final PlatformBuilder2<CupertinoFilledButtonData> cupertinoFilled;
+  final PlatformBuilder<MaterialRaisedButtonData> material;
+  final PlatformBuilder<MaterialFlatButtonData> materialFlat;
+  final PlatformBuilder<CupertinoButtonData> cupertino;
+  final PlatformBuilder<CupertinoFilledButtonData> cupertinoFilled;
 
   PlatformButton({
     Key key,

--- a/lib/src/platform_circluar_progress_indicator.dart
+++ b/lib/src/platform_circluar_progress_indicator.dart
@@ -48,8 +48,8 @@ class PlatformCircularProgressIndicator extends PlatformWidgetBase<
     CupertinoActivityIndicator, CircularProgressIndicator> {
   final Key widgetKey;
 
-  final PlatformBuilder2<MaterialProgressIndicatorData> material;
-  final PlatformBuilder2<CupertinoProgressIndicatorData> cupertino;
+  final PlatformBuilder<MaterialProgressIndicatorData> material;
+  final PlatformBuilder<CupertinoProgressIndicatorData> cupertino;
 
   PlatformCircularProgressIndicator({
     Key key,

--- a/lib/src/platform_dialog_action.dart
+++ b/lib/src/platform_dialog_action.dart
@@ -108,8 +108,8 @@ class PlatformDialogAction
   final Widget child;
   final VoidCallback onPressed;
 
-  final PlatformBuilder2<MaterialDialogActionData> material;
-  final PlatformBuilder2<CupertinoDialogActionData> cupertino;
+  final PlatformBuilder<MaterialDialogActionData> material;
+  final PlatformBuilder<CupertinoDialogActionData> cupertino;
 
   PlatformDialogAction({
     Key key,

--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -113,8 +113,8 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
   final EdgeInsets padding;
   final Color disabledColor;
 
-  final PlatformBuilder2<MaterialIconButtonData> material;
-  final PlatformBuilder2<CupertinoIconButtonData> cupertino;
+  final PlatformBuilder<MaterialIconButtonData> material;
+  final PlatformBuilder<CupertinoIconButtonData> cupertino;
 
   PlatformIconButton({
     Key key,

--- a/lib/src/platform_icons.dart
+++ b/lib/src/platform_icons.dart
@@ -534,10 +534,7 @@ class PlatformIcons {
   //     isMaterial(context) ? Icons.share : CupertinoIcons.shuffle_thick;
 
   /// Icons: Icons.star : CupertinoIcons.(custom)
-  IconData get star => isMaterial(context)
-      ? Icons.star
-      : const IconData(0xf2fc,
-          fontFamily: 'CupertinoIcons', fontPackage: 'cupertino_icons');
+  IconData get star => isMaterial(context) ? Icons.star : CupertinoIcons.star;
 
   /// Icons: Icons.switch_camera : CupertinoIcons.switch_camera
   IconData get switchCamera =>
@@ -564,6 +561,25 @@ class PlatformIcons {
 
   // IconData get tagsSolid =>
   //     isMaterial(context) ? Icons. : CupertinoIcons.tags_solid;
+
+  /// Icons: Icons.thumb_down : CupertinoIcons.hand_thumbsdown_fill
+  IconData get thumbDown => isMaterial(context)
+      ? Icons.thumb_down
+      : CupertinoIcons.hand_thumbsdown_fill;
+
+  /// Icons: Icons.thumb_down_outlined : CupertinoIcons.hand_thumbsdown
+  IconData get thumbDownOutlined => isMaterial(context)
+      ? Icons.thumb_down_outlined
+      : CupertinoIcons.hand_thumbsdown;
+
+  /// Icons: Icons.thumb_up : CupertinoIcons.hand_thumbsup_fill
+  IconData get thumbUp =>
+      isMaterial(context) ? Icons.thumb_up : CupertinoIcons.hand_thumbsup_fill;
+
+  /// Icons: Icons.thumb_up_outlined : CupertinoIcons.hand_thumbsup
+  IconData get thumbUpOutlined => isMaterial(context)
+      ? Icons.thumb_up_outlined
+      : CupertinoIcons.hand_thumbsup;
 
   /// Icons: Icons.schedule : CupertinoIcons.time
   IconData get time =>

--- a/lib/src/platform_nav_bar.dart
+++ b/lib/src/platform_nav_bar.dart
@@ -121,8 +121,8 @@ class PlatformNavBar extends PlatformWidgetBase<CupertinoTabBar, BottomAppBar> {
   final ValueChanged<int> itemChanged;
   final int currentIndex;
 
-  final PlatformBuilder2<MaterialNavBarData> material;
-  final PlatformBuilder2<CupertinoTabBarData> cupertino;
+  final PlatformBuilder<MaterialNavBarData> material;
+  final PlatformBuilder<CupertinoTabBarData> cupertino;
 
   PlatformNavBar({
     Key key,

--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -114,8 +114,8 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
   final PlatformNavBar bottomNavBar;
   final IndexedWidgetBuilder cupertinoTabChildBuilder;
 
-  final PlatformBuilder2<MaterialScaffoldData> material;
-  final PlatformBuilder2<CupertinoPageScaffoldData> cupertino;
+  final PlatformBuilder<MaterialScaffoldData> material;
+  final PlatformBuilder<CupertinoPageScaffoldData> cupertino;
 
   final bool iosContentPadding;
   final bool iosContentBottomPadding;

--- a/lib/src/platform_slider.dart
+++ b/lib/src/platform_slider.dart
@@ -111,8 +111,8 @@ class PlatformSlider extends PlatformWidgetBase<CupertinoSlider, Slider> {
   final double min;
   final double max;
 
-  final PlatformBuilder2<MaterialSliderData> material;
-  final PlatformBuilder2<CupertinoSliderData> cupertino;
+  final PlatformBuilder<MaterialSliderData> material;
+  final PlatformBuilder<CupertinoSliderData> cupertino;
 
   PlatformSlider({
     Key key,

--- a/lib/src/platform_switch.dart
+++ b/lib/src/platform_switch.dart
@@ -100,8 +100,8 @@ class PlatformSwitch extends PlatformWidgetBase<CupertinoSwitch, Switch> {
   final ValueChanged<bool> onChanged;
   final DragStartBehavior dragStartBehavior;
 
-  final PlatformBuilder2<MaterialSwitchData> material;
-  final PlatformBuilder2<CupertinoSwitchData> cupertino;
+  final PlatformBuilder<MaterialSwitchData> material;
+  final PlatformBuilder<CupertinoSwitchData> cupertino;
 
   PlatformSwitch({
     Key key,

--- a/lib/src/platform_text_field.dart
+++ b/lib/src/platform_text_field.dart
@@ -15,6 +15,7 @@ import 'package:flutter/cupertino.dart'
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart'
     show InputDecoration, TextField, InputCounterWidgetBuilder;
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart'
     show
@@ -53,51 +54,53 @@ const BoxDecoration _kDefaultRoundedBorderDecoration = BoxDecoration(
   borderRadius: BorderRadius.all(Radius.circular(5.0)),
 );
 
-InputDecoration _inputDecorationWithHint(String hint, InputDecoration inputDecoration) {
+InputDecoration _inputDecorationWithHint(
+    String hintText, InputDecoration inputDecoration) {
   return InputDecoration(
-    alignLabelWithHint: inputDecoration?.alignLabelWithHint ?? null,
-    border: inputDecoration?.border ?? null,
-    contentPadding: inputDecoration?.contentPadding ?? null,
-    counter: inputDecoration?.counter ?? null,
-    counterStyle: inputDecoration?.counterStyle ?? null,
-    counterText: inputDecoration?.counterText ?? null,
-    disabledBorder: inputDecoration?.disabledBorder ?? null,
-    enabled: inputDecoration?.enabled ?? null,
-    enabledBorder: inputDecoration?.enabledBorder ?? null,
-    errorBorder: inputDecoration?.errorBorder ?? null,
-    errorMaxLines: inputDecoration?.errorMaxLines ?? null,
-    errorStyle: inputDecoration?.errorStyle ?? null,
-    errorText: inputDecoration?.errorText ?? null,
-    fillColor: inputDecoration?.fillColor ?? null,
-    filled: inputDecoration?.filled ?? null,
-    floatingLabelBehavior: inputDecoration?.floatingLabelBehavior ?? null,
-    focusColor: inputDecoration?.focusColor ?? null,
-    focusedBorder: inputDecoration?.focusedBorder ?? null,
-    focusedErrorBorder: inputDecoration?.focusedErrorBorder ?? null,
-    hasFloatingPlaceholder: inputDecoration?.hasFloatingPlaceholder ?? null,
-    helperMaxLines: inputDecoration?.helperMaxLines ?? null,
-    helperStyle: inputDecoration?.helperStyle ?? null,
-    helperText: inputDecoration?.helperText ?? null,
-    hintMaxLines: inputDecoration?.hintMaxLines ?? null,
-    hintStyle: inputDecoration?.hintStyle ?? null,
-    hintText: hint,
-    hoverColor: inputDecoration?.hoverColor ?? null,
-    icon: inputDecoration?.icon ?? null,
-    isCollapsed: inputDecoration?.isCollapsed ?? null,
-    isDense: inputDecoration?.isDense ?? null,
-    labelStyle: inputDecoration?.labelStyle ?? null,
-    labelText: inputDecoration?.labelText ?? null,
-    prefix: inputDecoration?.prefix ?? null,
-    prefixIcon: inputDecoration?.prefixIcon ?? null,
-    prefixIconConstraints: inputDecoration?.prefixIconConstraints ?? null,
-    prefixStyle: inputDecoration?.prefixStyle ?? null,
-    prefixText: inputDecoration?.prefixText ?? null,
-    semanticCounterText: inputDecoration?.semanticCounterText ?? null,
-    suffix: inputDecoration?.suffix ?? null,
-    suffixIcon: inputDecoration?.suffixIcon ?? null,
-    suffixIconConstraints: inputDecoration?.suffixIconConstraints ?? null,
-    suffixStyle: inputDecoration?.suffixStyle ?? null,
-    suffixText: inputDecoration?.suffixText ?? null,
+    alignLabelWithHint: inputDecoration?.alignLabelWithHint,
+    border: inputDecoration?.border,
+    contentPadding: inputDecoration?.contentPadding,
+    counter: inputDecoration?.counter,
+    counterStyle: inputDecoration?.counterStyle,
+    counterText: inputDecoration?.counterText,
+    disabledBorder: inputDecoration?.disabledBorder,
+    enabled: inputDecoration?.enabled ?? true,
+    enabledBorder: inputDecoration?.enabledBorder,
+    errorBorder: inputDecoration?.errorBorder,
+    errorMaxLines: inputDecoration?.errorMaxLines,
+    errorStyle: inputDecoration?.errorStyle,
+    errorText: inputDecoration?.errorText,
+    fillColor: inputDecoration?.fillColor,
+    filled: inputDecoration?.filled,
+    floatingLabelBehavior:
+        inputDecoration?.floatingLabelBehavior ?? FloatingLabelBehavior.auto,
+    focusColor: inputDecoration?.focusColor,
+    focusedBorder: inputDecoration?.focusedBorder,
+    focusedErrorBorder: inputDecoration?.focusedErrorBorder,
+    hasFloatingPlaceholder: inputDecoration?.hasFloatingPlaceholder ?? true,
+    helperMaxLines: inputDecoration?.helperMaxLines,
+    helperStyle: inputDecoration?.helperStyle,
+    helperText: inputDecoration?.helperText,
+    hintMaxLines: inputDecoration?.hintMaxLines,
+    hintStyle: inputDecoration?.hintStyle,
+    hintText: hintText ?? inputDecoration?.hintText,
+    hoverColor: inputDecoration?.hoverColor,
+    icon: inputDecoration?.icon,
+    isCollapsed: inputDecoration?.isCollapsed ?? false,
+    isDense: inputDecoration?.isDense,
+    labelStyle: inputDecoration?.labelStyle,
+    labelText: inputDecoration?.labelText,
+    prefix: inputDecoration?.prefix,
+    prefixIcon: inputDecoration?.prefixIcon,
+    prefixIconConstraints: inputDecoration?.prefixIconConstraints,
+    prefixStyle: inputDecoration?.prefixStyle,
+    prefixText: inputDecoration?.prefixText,
+    semanticCounterText: inputDecoration?.semanticCounterText,
+    suffix: inputDecoration?.suffix,
+    suffixIcon: inputDecoration?.suffixIcon,
+    suffixIconConstraints: inputDecoration?.suffixIconConstraints,
+    suffixStyle: inputDecoration?.suffixStyle,
+    suffixText: inputDecoration?.suffixText,
   );
 }
 
@@ -378,8 +381,8 @@ class PlatformTextField
 
   final double cursorHeight;
   final String restorationId;
-  
-  final String hint;
+
+  final String hintText;
 
   PlatformTextField({
     Key key,
@@ -427,7 +430,7 @@ class PlatformTextField
     this.autofillHints,
     this.cursorHeight,
     this.restorationId,
-    this.hint,
+    this.hintText,
     this.material,
     this.cupertino,
   })  : keyboardType = keyboardType ??
@@ -438,7 +441,10 @@ class PlatformTextField
   TextField createMaterialWidget(BuildContext context) {
     final data = material?.call(context, platform(context));
 
-    final decoration = _inputDecorationWithHint(hint, data?.decoration ?? const InputDecoration());
+    final decoration = (hintText == null)
+        ? data?.decoration ?? const InputDecoration()
+        : _inputDecorationWithHint(
+            hintText, data?.decoration ?? const InputDecoration());
 
     return TextField(
       key: data?.widgetKey ?? widgetKey,
@@ -542,7 +548,7 @@ class PlatformTextField
       decoration: data?.decoration ?? _kDefaultRoundedBorderDecoration,
       clearButtonMode: data?.clearButtonMode ?? OverlayVisibilityMode.never,
       padding: data?.padding ?? const EdgeInsets.all(6.0),
-      placeholder: data?.placeholder ?? hint,
+      placeholder: data?.placeholder ?? hintText,
       placeholderStyle: data?.placeholderStyle ??
           const TextStyle(
             fontWeight: FontWeight.w400,

--- a/lib/src/platform_text_field.dart
+++ b/lib/src/platform_text_field.dart
@@ -328,8 +328,8 @@ class PlatformTextField
     extends PlatformWidgetBase<CupertinoTextField, TextField> {
   final Key widgetKey;
 
-  final PlatformBuilder2<MaterialTextFieldData> material;
-  final PlatformBuilder2<CupertinoTextFieldData> cupertino;
+  final PlatformBuilder<MaterialTextFieldData> material;
+  final PlatformBuilder<CupertinoTextFieldData> cupertino;
 
   final TextEditingController controller;
   final FocusNode focusNode;

--- a/lib/src/platform_text_field.dart
+++ b/lib/src/platform_text_field.dart
@@ -53,6 +53,54 @@ const BoxDecoration _kDefaultRoundedBorderDecoration = BoxDecoration(
   borderRadius: BorderRadius.all(Radius.circular(5.0)),
 );
 
+InputDecoration _inputDecorationWithHint(String hint, InputDecoration inputDecoration) {
+  return InputDecoration(
+    alignLabelWithHint: inputDecoration?.alignLabelWithHint ?? null,
+    border: inputDecoration?.border ?? null,
+    contentPadding: inputDecoration?.contentPadding ?? null,
+    counter: inputDecoration?.counter ?? null,
+    counterStyle: inputDecoration?.counterStyle ?? null,
+    counterText: inputDecoration?.counterText ?? null,
+    disabledBorder: inputDecoration?.disabledBorder ?? null,
+    enabled: inputDecoration?.enabled ?? null,
+    enabledBorder: inputDecoration?.enabledBorder ?? null,
+    errorBorder: inputDecoration?.errorBorder ?? null,
+    errorMaxLines: inputDecoration?.errorMaxLines ?? null,
+    errorStyle: inputDecoration?.errorStyle ?? null,
+    errorText: inputDecoration?.errorText ?? null,
+    fillColor: inputDecoration?.fillColor ?? null,
+    filled: inputDecoration?.filled ?? null,
+    floatingLabelBehavior: inputDecoration?.floatingLabelBehavior ?? null,
+    focusColor: inputDecoration?.focusColor ?? null,
+    focusedBorder: inputDecoration?.focusedBorder ?? null,
+    focusedErrorBorder: inputDecoration?.focusedErrorBorder ?? null,
+    hasFloatingPlaceholder: inputDecoration?.hasFloatingPlaceholder ?? null,
+    helperMaxLines: inputDecoration?.helperMaxLines ?? null,
+    helperStyle: inputDecoration?.helperStyle ?? null,
+    helperText: inputDecoration?.helperText ?? null,
+    hintMaxLines: inputDecoration?.hintMaxLines ?? null,
+    hintStyle: inputDecoration?.hintStyle ?? null,
+    hintText: hint,
+    hoverColor: inputDecoration?.hoverColor ?? null,
+    icon: inputDecoration?.icon ?? null,
+    isCollapsed: inputDecoration?.isCollapsed ?? null,
+    isDense: inputDecoration?.isDense ?? null,
+    labelStyle: inputDecoration?.labelStyle ?? null,
+    labelText: inputDecoration?.labelText ?? null,
+    prefix: inputDecoration?.prefix ?? null,
+    prefixIcon: inputDecoration?.prefixIcon ?? null,
+    prefixIconConstraints: inputDecoration?.prefixIconConstraints ?? null,
+    prefixStyle: inputDecoration?.prefixStyle ?? null,
+    prefixText: inputDecoration?.prefixText ?? null,
+    semanticCounterText: inputDecoration?.semanticCounterText ?? null,
+    suffix: inputDecoration?.suffix ?? null,
+    suffixIcon: inputDecoration?.suffixIcon ?? null,
+    suffixIconConstraints: inputDecoration?.suffixIconConstraints ?? null,
+    suffixStyle: inputDecoration?.suffixStyle ?? null,
+    suffixText: inputDecoration?.suffixText ?? null,
+  );
+}
+
 class MaterialTextFieldData {
   MaterialTextFieldData({
     this.widgetKey,
@@ -330,6 +378,8 @@ class PlatformTextField
 
   final double cursorHeight;
   final String restorationId;
+  
+  final String hint;
 
   PlatformTextField({
     Key key,
@@ -377,6 +427,7 @@ class PlatformTextField
     this.autofillHints,
     this.cursorHeight,
     this.restorationId,
+    this.hint,
     this.material,
     this.cupertino,
   })  : keyboardType = keyboardType ??
@@ -386,6 +437,8 @@ class PlatformTextField
   @override
   TextField createMaterialWidget(BuildContext context) {
     final data = material?.call(context, platform(context));
+
+    final decoration = _inputDecorationWithHint(hint, data?.decoration ?? const InputDecoration());
 
     return TextField(
       key: data?.widgetKey ?? widgetKey,
@@ -415,7 +468,7 @@ class PlatformTextField
           textCapitalization ??
           TextCapitalization.none,
       textInputAction: data?.textInputAction ?? textInputAction,
-      decoration: data?.decoration ?? const InputDecoration(),
+      decoration: decoration,
       textDirection: data?.textDirection,
       buildCounter: data?.buildCounter,
       dragStartBehavior: data?.dragStartBehavior ??
@@ -489,7 +542,7 @@ class PlatformTextField
       decoration: data?.decoration ?? _kDefaultRoundedBorderDecoration,
       clearButtonMode: data?.clearButtonMode ?? OverlayVisibilityMode.never,
       padding: data?.padding ?? const EdgeInsets.all(6.0),
-      placeholder: data?.placeholder,
+      placeholder: data?.placeholder ?? hint,
       placeholderStyle: data?.placeholderStyle ??
           const TextStyle(
             fontWeight: FontWeight.w400,

--- a/lib/src/platform_widget.dart
+++ b/lib/src/platform_widget.dart
@@ -10,8 +10,8 @@ import 'platform.dart';
 import 'widget_base.dart';
 
 class PlatformWidget extends PlatformWidgetBase<Widget, Widget> {
-  final PlatformBuilder2<Widget> material;
-  final PlatformBuilder2<Widget> cupertino;
+  final PlatformBuilder<Widget> material;
+  final PlatformBuilder<Widget> cupertino;
 
   PlatformWidget({
     Key key,

--- a/lib/src/widget_base.dart
+++ b/lib/src/widget_base.dart
@@ -9,9 +9,9 @@ import 'package:flutter/widgets.dart';
 
 import 'platform.dart';
 
-typedef T PlatformBuilder<T>(BuildContext context);
-
-typedef T PlatformBuilder2<T>(BuildContext context, PlatformTarget platform);
+typedef T PlatformBuilder<T>(BuildContext context, PlatformTarget platform);
+typedef T PlatformIndexBuilder<T>(
+    BuildContext context, PlatformTarget platform, int index);
 
 abstract class PlatformWidgetBase<I extends Widget, A extends Widget>
     extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_platform_widgets
 description: Simplifying the use of both Material and Cupertino widgets with a single widget
-version: 0.71.0
+version: 0.72.0
 homepage: https://github.com/aqwert/flutter_platform_widgets
 
 environment:


### PR DESCRIPTION
Adds a hint to both cupertino and material-style textfields (directly through property `placeholder` for cupertino and through `decoration` (which, in turn, has a property `hint`) for material).