### PR TITLE
deleted no longer suported property

### DIFF
--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -199,7 +199,6 @@ class PlatformAppBar
         key: data?.widgetKey ?? widgetKey,
         middle: data?.title ?? title,
         backgroundColor: data?.backgroundColor ?? backgroundColor,
-        actionsForegroundColor: data?.actionsForegroundColor,
         automaticallyImplyLeading: data?.automaticallyImplyLeading ??
             automaticallyImplyLeading ??
             true,
@@ -219,7 +218,6 @@ class PlatformAppBar
       key: data?.widgetKey ?? widgetKey,
       middle: data?.title ?? title,
       backgroundColor: data?.backgroundColor ?? backgroundColor,
-      actionsForegroundColor: data?.actionsForegroundColor,
       automaticallyImplyLeading:
           data?.automaticallyImplyLeading ?? automaticallyImplyLeading ?? true,
       automaticallyImplyMiddle: data?.automaticallyImplyMiddle ?? true,


### PR DESCRIPTION
Removed a no longer supported property of `CupertinoNavigationBar`  up from Flutter Version 1.26.0
You probably also will have to delete it in your null-safe version