### PR TITLE
#176 Add Platform theme

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,10 +16,11 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final cupertinoTheme = CupertinoThemeData(
+      primaryColor: Color(0xff127EFB),
+    );
+
     final materialTheme = ThemeData(
-      cupertinoOverrideTheme: CupertinoThemeData(
-        primaryColor: Color(0xff127EFB),
-      ),
       primarySwatch: Colors.green,
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: ButtonStyle(
@@ -29,8 +30,10 @@ class MyApp extends StatelessWidget {
       ),
     );
 
-    return Theme(
-      data: materialTheme,
+    return PlatformTheme(
+      //primaryColor: Colors.green, // both platforms will get this color
+      materialTheme: materialTheme,
+      cupertinoTheme: cupertinoTheme,
       child: PlatformProvider(
         settings: PlatformSettingsData(iosUsesMaterialWidgets: true),
         builder: (context) => PlatformApp(
@@ -41,14 +44,6 @@ class MyApp extends StatelessWidget {
           ],
           title: 'Flutter Platform Widgets',
           home: PlatformPage(),
-          material: (_, __) => MaterialAppData(
-            theme: materialTheme,
-          ),
-          cupertino: (_, __) => CupertinoAppData(
-            theme: CupertinoThemeData(
-              primaryColor: Color(0xff127EFB),
-            ),
-          ),
         ),
       ),
     );
@@ -79,7 +74,6 @@ class PlatformPage extends StatelessWidget {
                 }),
           ),
           Divider(thickness: 10),
-
           // ! PlatformText
           PlatformWidgetExample(
             title: 'PlatformText',
@@ -188,6 +182,7 @@ class PlatformPage extends StatelessWidget {
               ),
             ),
           ),
+
           // ! PlatformIconButton
           PlatformWidgetExample(
             title: 'PlatformIconButton',

--- a/lib/flutter_platform_widgets.dart
+++ b/lib/flutter_platform_widgets.dart
@@ -37,6 +37,7 @@ export 'src/platform_text.dart';
 export 'src/platform_text_button.dart';
 export 'src/platform_text_field.dart';
 export 'src/platform_text_form_field.dart';
+export 'src/platform_theme.dart';
 export 'src/platform_widget.dart';
 export 'src/platform_widget_builder.dart';
 export 'src/widget_base.dart';

--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -4,9 +4,11 @@
  * See LICENSE for distribution and usage details.
  */
 
-import 'package:flutter/cupertino.dart' show CupertinoApp, CupertinoThemeData;
+import 'package:flutter/cupertino.dart'
+    show CupertinoApp, CupertinoTheme, CupertinoThemeData;
 import 'package:flutter/material.dart'
     show MaterialApp, ScaffoldMessengerState, Theme, ThemeData, ThemeMode;
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'platform.dart';
@@ -560,6 +562,11 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
       );
     } else {
       final data = material?.call(context, platform(context));
+      final themeData = Theme.of(context);
+      final lightTheme =
+          themeData.brightness == Brightness.light ? themeData : null;
+      final darkTheme =
+          themeData.brightness == Brightness.dark ? themeData : null;
       return MaterialApp(
         key: data?.widgetKey ?? widgetKey,
         navigatorKey: data?.navigatorKey ?? navigatorKey,
@@ -598,10 +605,11 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
         debugShowCheckedModeBanner: data?.debugShowCheckedModeBanner ??
             debugShowCheckedModeBanner ??
             true,
-        theme: (data?.theme ?? Theme.of(context))
-            .copyWith(platform: TargetPlatform.android),
+        theme: (data?.theme ?? lightTheme)
+            ?.copyWith(platform: TargetPlatform.android),
         debugShowMaterialGrid: data?.debugShowMaterialGrid ?? false,
-        darkTheme: data?.darkTheme?.copyWith(platform: TargetPlatform.android),
+        darkTheme: (data?.darkTheme ?? darkTheme)
+            ?.copyWith(platform: TargetPlatform.android),
         themeMode: data?.themeMode ?? ThemeMode.system,
         shortcuts: data?.shortcuts ?? shortcuts,
         actions: data?.actions ?? actions,
@@ -708,7 +716,7 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
         debugShowCheckedModeBanner: data?.debugShowCheckedModeBanner ??
             debugShowCheckedModeBanner ??
             true,
-        theme: data?.theme,
+        theme: data?.theme ?? CupertinoTheme.of(context),
         shortcuts: data?.shortcuts ?? shortcuts,
         actions: data?.actions ?? actions,
         onGenerateInitialRoutes:

--- a/lib/src/platform_theme.dart
+++ b/lib/src/platform_theme.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Common theme control for Material and Cupertino styled apps
+///
+/// If [primaryColor], [accentColor], [bottomAppBarColor], [scaffoldBackgroundColor]
+/// are passed in then they will override the equivalent value within [ThemeData] and
+/// [CupertinoThemeData]. Ideally setting these mean that both platforms will have the
+/// same color. If requried to be differemnt instead set the [materialTheme] or [cupertinoTheme]
+/// parameters
+class PlatformTheme extends StatelessWidget {
+  final Widget child;
+
+  final ThemeData? materialTheme;
+  final CupertinoThemeData? cupertinoTheme;
+
+  /// Material [ThemeData.primaryColor] and Cupertino [CupertinoThemeData.primaryColor]
+  final Color? primaryColor;
+
+  /// Material [ThemeData.accentColor] and Cupertino [CupertinoThemeData.primaryContrastingColor]
+  final Color? accentColor;
+
+  /// Material [ThemeData.bottomAppBarColor] and Cupertino [CupertinoThemeData.barBackgroundColor]
+  final Color? bottomAppBarColor;
+
+  /// Material [ThemeData.scaffoldBackgroundColor] and Cupertino [CupertinoThemeData.scaffoldBackgroundColor]
+  final Color? scaffoldBackgroundColor;
+
+  const PlatformTheme({
+    Key? key,
+    required this.child,
+    this.primaryColor,
+    this.accentColor,
+    this.bottomAppBarColor,
+    this.scaffoldBackgroundColor,
+    this.materialTheme,
+    this.cupertinoTheme,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: _materialTheme(),
+      child: CupertinoTheme(
+        data: _cupertinoTheme(),
+        child: child,
+      ),
+    );
+  }
+
+  ThemeData _materialTheme() {
+    final theme = materialTheme ?? ThemeData.fallback();
+
+    return theme.copyWith(
+      cupertinoOverrideTheme: _cupertinoTheme(),
+      primaryColor: primaryColor ?? theme.primaryColor,
+      accentColor: accentColor ?? theme.accentColor,
+      scaffoldBackgroundColor:
+          scaffoldBackgroundColor ?? theme.scaffoldBackgroundColor,
+      bottomAppBarColor: bottomAppBarColor ?? theme.bottomAppBarColor,
+    );
+  }
+
+  CupertinoThemeData _cupertinoTheme() {
+    final theme = cupertinoTheme ?? const CupertinoThemeData();
+
+    return theme.copyWith(
+      primaryColor: primaryColor ?? theme.primaryColor,
+      primaryContrastingColor: accentColor ?? theme.primaryContrastingColor,
+      scaffoldBackgroundColor:
+          scaffoldBackgroundColor ?? theme.scaffoldBackgroundColor,
+      barBackgroundColor: bottomAppBarColor ?? theme.barBackgroundColor,
+    );
+  }
+}

--- a/lib/src/platform_theme.dart
+++ b/lib/src/platform_theme.dart
@@ -39,10 +39,11 @@ class PlatformTheme extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final materialTheme = _materialTheme();
     return Theme(
-      data: _materialTheme(),
+      data: materialTheme,
       child: CupertinoTheme(
-        data: _cupertinoTheme(),
+        data: _cupertinoTheme(materialTheme),
         child: child,
       ),
     );
@@ -51,18 +52,24 @@ class PlatformTheme extends StatelessWidget {
   ThemeData _materialTheme() {
     final theme = materialTheme ?? ThemeData.fallback();
 
-    return theme.copyWith(
-      cupertinoOverrideTheme: _cupertinoTheme(),
+    final updatedTheme = theme.copyWith(
       primaryColor: primaryColor ?? theme.primaryColor,
       accentColor: accentColor ?? theme.accentColor,
       scaffoldBackgroundColor:
           scaffoldBackgroundColor ?? theme.scaffoldBackgroundColor,
       bottomAppBarColor: bottomAppBarColor ?? theme.bottomAppBarColor,
     );
+
+    return updatedTheme.copyWith(
+      cupertinoOverrideTheme: _cupertinoTheme(updatedTheme),
+    );
   }
 
-  CupertinoThemeData _cupertinoTheme() {
-    final theme = cupertinoTheme ?? const CupertinoThemeData();
+  CupertinoThemeData _cupertinoTheme(ThemeData materialData) {
+    final theme = cupertinoTheme ??
+        MaterialBasedCupertinoThemeData(
+          materialTheme: materialData,
+        );
 
     return theme.copyWith(
       primaryColor: primaryColor ?? theme.primaryColor,


### PR DESCRIPTION
PlatformTheme allows for under simple use cases a basic common theme with color. If any substantial differences between the material and cupertino themes are needed then setting the `materialTheme` and `cupertinoTheme` properties will be better

Adding documentation update in another commit