### PR TITLE
Update minimum flutter version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/stryder-dev/flutter_platform_widgets
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.24.0"
+  flutter: ">=2.2.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Update minimum flutter version to `>=2.2.0`.

Due to #306 uses interfaces from the new version of flutter
Apps cannot be built with Flutter version under `2.2.0`.
