### PR TITLE
We should be allowed to define BottomNavBar for IOS and Drawer for Andoid

### DIFF
--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -191,7 +191,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
     final useMaterial = providerState?.settings.iosUsesMaterialWidgets ?? false;
 
     Widget result;
-    if (bottomNavBar != null) {
+    if (bottomNavBar != null || data?.bottomTabBar != null) {
       var tabBar =
           data?.bottomTabBar ?? bottomNavBar?.createCupertinoWidget(context);
 


### PR DESCRIPTION
We should be allowed to define BottomNavBar for IOS and Drawer for Andoid

```dart
    return PlatformScaffold(
      appBar: PlatformAppBar(
        title: const Text('MyApp'),
      ),
      body: _body(context),
      cupertino: (_, __) => CupertinoPageScaffoldData(
        bottomTabBar: CupertinoTabBar(
            items: [...generateCupertinoBottomNavigationBarItem(context)]),
      ),
      material: (_, __) => MaterialScaffoldData(
          drawer: Drawer(
        child: drawerItems,
      )),
    );
```

Thanks for you review !