### PR TITLE
Use kThemeAnimationDuration from material

### DIFF
--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -6,13 +6,17 @@
 
 import 'package:flutter/cupertino.dart' show CupertinoApp, CupertinoThemeData;
 import 'package:flutter/material.dart'
-    show MaterialApp, ScaffoldMessengerState, Theme, ThemeData, ThemeMode;
+    show
+        MaterialApp,
+        ScaffoldMessengerState,
+        Theme,
+        ThemeData,
+        ThemeMode,
+        kThemeAnimationDuration;
 import 'package:flutter/widgets.dart';
 
 import 'platform.dart';
 import 'widget_base.dart';
-
-const Duration kThemeAnimationDuration = Duration(milliseconds: 200);
 
 abstract class _BaseData {
   _BaseData({


### PR DESCRIPTION
With Flutter 3.7 there is a import conflict that the variable `kThemeAnimationDuration`  is defined in both `PlatformApp` and `Theme.dart`. I see no reason why we should define it ourselves and not use it from Theme.

Error:

`Error: 'kThemeAnimationDuration' is imported from both 'package:flutter/src/material/theme.dart' and 'package:flutter_platform_widgets/src/platform_app.dart'.`

Therefore, I removed the variable and used the identical one from Material.