### PR TITLE
Remove debug print for material app

### DIFF
--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -460,8 +460,6 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
   createMaterialWidget(BuildContext context) {
     final dataRouter = materialRouter?.call(context, platform(context));
 
-    debugPrint('BUILD Material app');
-
     if (routeInformationParser != null ||
         dataRouter?.routeInformationParser != null ||
         routerConfig != null ||


### PR DESCRIPTION
A debug print has recently been added to the package when building a material app. This is unnecessary and has been removed with this pull request.