### PR TITLE
possible copy and paste error for darkTheme on android

### DIFF
--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -588,7 +588,7 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
                 _getMaterialLightThemeData(context) ??
                 Theme.of(context))
             .copyWith(platform: TargetPlatform.android),
-        darkTheme: (dataRouter?.darkTheme ?? _getMaterialDarkThemeData(context))
+        darkTheme: (data?.darkTheme ?? _getMaterialDarkThemeData(context))
             ?.copyWith(platform: TargetPlatform.android),
         themeMode: data?.themeMode ??
             _getMaterialThemeMode(context) ??


### PR DESCRIPTION
MaterialApp got created with darkTheme taken from "dataRouter" instead of "data"

fixed that