### PR TITLE
Cleanup of some common lints

### DIFF
--- a/example/lib/cupertino_date_picker.dart
+++ b/example/lib/cupertino_date_picker.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
-showDatePickerWithCustomCupertinoStateful(BuildContext context) async {
+Future<void> showDatePickerWithCustomCupertinoStateful(BuildContext context) async {
   final now = DateUtils.dateOnly(DateTime.now());
   final firstDate = now.subtract(const Duration(days: 100));
   final lastDate = now.add(const Duration(days: 100));
@@ -23,7 +23,7 @@ showDatePickerWithCustomCupertinoStateful(BuildContext context) async {
   }
 }
 
-showDatePickerWithCustomCupertino(BuildContext context) async {
+Future<void> showDatePickerWithCustomCupertino(BuildContext context) async {
   final now = DateUtils.dateOnly(DateTime.now());
   final firstDate = now.subtract(const Duration(days: 100));
   final lastDate = now.add(const Duration(days: 100));
@@ -61,7 +61,7 @@ showDatePickerWithCustomCupertino(BuildContext context) async {
   }
 }
 
-_showResultDialog(BuildContext context, String text) {
+void _showResultDialog(BuildContext context, String text) {
   showPlatformDialog(
     context: context,
     builder: (_) => PlatformAlertDialog(

--- a/example/lib/cupertino_date_picker.dart
+++ b/example/lib/cupertino_date_picker.dart
@@ -65,7 +65,7 @@ _showResultDialog(BuildContext context, String text) {
   showPlatformDialog(
     context: context,
     builder: (_) => PlatformAlertDialog(
-      title: Text('Alert'),
+      title: const Text('Alert'),
       content: Text('$text content'),
       actions: <Widget>[
         PlatformDialogAction(

--- a/example/lib/icons_page.dart
+++ b/example/lib/icons_page.dart
@@ -274,7 +274,7 @@ class IconsPage extends StatelessWidget {
 }
 
 class _IconCompared extends StatelessWidget {
-  _IconCompared(this.title, this.icon);
+  const _IconCompared(this.title, this.icon);
 
   final String title;
   final IconData Function(BuildContext context) icon;

--- a/example/lib/icons_page.dart
+++ b/example/lib/icons_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'platform_widget_example.dart';
 
 class IconsPage extends StatelessWidget {
+  const IconsPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(

--- a/example/lib/icons_page.dart
+++ b/example/lib/icons_page.dart
@@ -16,7 +16,7 @@ class IconsPage extends StatelessWidget {
             padding: const EdgeInsets.all(8.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
+              children: const <Widget>[
                 Expanded(
                   child: Text(
                     'Material',

--- a/example/lib/icons_page.dart
+++ b/example/lib/icons_page.dart
@@ -8,15 +8,15 @@ class IconsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return PlatformScaffold(
       iosContentPadding: true,
-      appBar: PlatformAppBar(title: Text('Platform Icons')),
+      appBar: const PlatformAppBar(title: Text('Platform Icons')),
       body: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
+          const Padding(
+            padding: EdgeInsets.all(8.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: const <Widget>[
+              children: <Widget>[
                 Expanded(
                   child: Text(
                     'Material',
@@ -32,7 +32,7 @@ class IconsPage extends StatelessWidget {
               ],
             ),
           ),
-          Divider(
+          const Divider(
             thickness: 2,
           ),
           Expanded(

--- a/example/lib/logo.dart
+++ b/example/lib/logo.dart
@@ -36,7 +36,7 @@ class FlutterPlatformWidgetsLogo extends StatelessWidget {
         ),
       ),
       CupertinoButton.filled(
-        padding: EdgeInsets.all(8),
+        padding: const EdgeInsets.all(8),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Text(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,8 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
   @override
   State<MyApp> createState() => _MyAppState();
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,7 @@ class _MyAppState extends State<MyApp> {
           this.themeMode = themeMode; /* you can save to storage */
         },
         builder: (context) => PlatformApp(
-          localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
             DefaultMaterialLocalizations.delegate,
             DefaultWidgetsLocalizations.delegate,
             DefaultCupertinoLocalizations.delegate,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'platform_page.dart.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatefulWidget {
@@ -59,8 +59,8 @@ class _MyAppState extends State<MyApp> {
         onThemeModeChanged: (themeMode) {
           this.themeMode = themeMode; /* you can save to storage */
         },
-        builder: (context) => PlatformApp(
-          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+        builder: (context) => const PlatformApp(
+          localizationsDelegates: <LocalizationsDelegate<dynamic>>[
             DefaultMaterialLocalizations.delegate,
             DefaultWidgetsLocalizations.delegate,
             DefaultCupertinoLocalizations.delegate,

--- a/example/lib/material_ios_page.dart
+++ b/example/lib/material_ios_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 /// Page to show what material widgets look like on cupertino
 class IosMaterialPage extends StatelessWidget {
+  const IosMaterialPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(

--- a/example/lib/material_ios_page.dart
+++ b/example/lib/material_ios_page.dart
@@ -7,10 +7,10 @@ class IosMaterialPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return PlatformScaffold(
       appBar: PlatformAppBar(
-        title: Text('iOS with Material'),
+        title: const Text('iOS with Material'),
         trailingActions: [
           // This is possible because of PlatformProvider iosUsesMaterialWidgets setting
-          IconButton(icon: Icon(Icons.ac_unit), onPressed: () {}),
+          IconButton(icon: const Icon(Icons.ac_unit), onPressed: () {}),
         ],
         cupertino: (_, __) => CupertinoNavigationBarData(
             // If this is enabled and set to true then the IconButton above will complain of no parent Material widget
@@ -20,17 +20,17 @@ class IosMaterialPage extends StatelessWidget {
       body: ListView(
         children: [
           IconButton(
-            icon: Icon(Icons.book),
+            icon: const Icon(Icons.book),
             onPressed: () {},
           ),
-          Divider(
+          const Divider(
             thickness: 6,
           ),
           ListTile(
-            title: Text('List Tile title'),
-            subtitle: Text('sub title'),
+            title: const Text('List Tile title'),
+            subtitle: const Text('sub title'),
             onTap: () {},
-            trailing: Icon(Icons.place),
+            trailing: const Icon(Icons.place),
           ),
         ],
       ),

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -58,8 +58,8 @@ class PlatformPage extends StatelessWidget {
                   'PlatformSearchBar ${isMaterial(context) ? " (Material 3 only)" : ""}',
               builder: (context, platform) => PlatformSearchBar(
                 onChanged: (value) =>
-                    print('${platform.text} SearchBar changed: $value'),
-                onTap: () => print('${platform.text} SearchBar tapped'),
+                    debugPrint('${platform.text} SearchBar changed: $value'),
+                onTap: () => debugPrint('${platform.text} SearchBar tapped'),
                 hintText: '${platform.text} SearchBar',
               ),
             ),
@@ -71,7 +71,7 @@ class PlatformPage extends StatelessWidget {
                 title: PlatformText('title'),
                 subtitle: PlatformText('subtitle'),
                 trailing: Icon(context.platformIcons.rightChevron),
-                onTap: () => print('${platform.text} PlatformListTile'),
+                onTap: () => debugPrint('${platform.text} PlatformListTile'),
               ),
             ),
             // ! PlatformText
@@ -147,7 +147,7 @@ class PlatformPage extends StatelessWidget {
               title: 'PlatformElevatedButton',
               builder: (_, platform) => PlatformElevatedButton(
                 child: Text(platform.text),
-                onPressed: () => print('${platform.text} PlatformButton'),
+                onPressed: () => debugPrint('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
                 color: Colors.orange,
               ),
@@ -156,7 +156,7 @@ class PlatformPage extends StatelessWidget {
               title: 'PlatformElevatedButton Icon',
               builder: (_, platform) => PlatformElevatedButton(
                 child: Text(platform.text),
-                onPressed: () => print('${platform.text} PlatformButton'),
+                onPressed: () => debugPrint('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
                 material: (_, __) => MaterialElevatedButtonData(
                   icon: const Icon(Icons.home),
@@ -171,7 +171,7 @@ class PlatformPage extends StatelessWidget {
               title: 'PlatformTextButton',
               builder: (_, platform) => PlatformTextButton(
                 child: Text(platform.text),
-                onPressed: () => print('${platform.text} PlatformButton'),
+                onPressed: () => debugPrint('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
               ),
             ),
@@ -179,7 +179,7 @@ class PlatformPage extends StatelessWidget {
               title: 'PlatformTextButton Icon',
               builder: (_, platform) => PlatformTextButton(
                 child: Text(platform.text),
-                onPressed: () => print('${platform.text} PlatformButton'),
+                onPressed: () => debugPrint('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
                 material: (_, __) => MaterialTextButtonData(
                   icon: const Icon(Icons.home),
@@ -258,11 +258,11 @@ class PlatformPage extends StatelessWidget {
               builder: (_, platform) => PlatformWidgetBuilder(
                 cupertino: (_, child, __) => GestureDetector(
                   child: child,
-                  onTap: () => print('Cupertino PlatformWidgetBuilder'),
+                  onTap: () => debugPrint('Cupertino PlatformWidgetBuilder'),
                 ),
                 material: (_, child, __) => InkWell(
                   child: child,
-                  onTap: () => print('Material PlatformWidgetBuilder'),
+                  onTap: () => debugPrint('Material PlatformWidgetBuilder'),
                 ),
                 child: Container(
                   padding: const EdgeInsets.all(12),

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -68,8 +68,8 @@ class PlatformPage extends StatelessWidget {
               title: 'PlatformListTile',
               builder: (_, platform) => PlatformListTile(
                 leading: Icon(context.platformIcons.book),
-                title: PlatformText("title"),
-                subtitle: PlatformText("subtitle"),
+                title: PlatformText('title'),
+                subtitle: PlatformText('subtitle'),
                 trailing: Icon(context.platformIcons.rightChevron),
                 onTap: () => print('${platform.text} PlatformListTile'),
               ),

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -15,15 +15,15 @@ class PlatformPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(
-      appBar: PlatformAppBar(
+      appBar: const PlatformAppBar(
         title: Text('Flutter Platform Widgets'),
       ),
       body: PlatformScrollbar(
         thumbVisibility: true,
         child: ListView(
           children: [
-            FlutterPlatformWidgetsLogo(size: 60),
-            Divider(thickness: 10),
+            const FlutterPlatformWidgetsLogo(size: 60),
+            const Divider(thickness: 10),
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: PlatformElevatedButton(
@@ -49,7 +49,7 @@ class PlatformPage extends StatelessWidget {
                     PlatformTheme.of(context)?.themeMode = newMode;
                   }),
             ),
-            Divider(thickness: 10),
+            const Divider(thickness: 10),
             // ! PlatformSearchBar
             PlatformWidgetExample(
               title:
@@ -157,7 +157,7 @@ class PlatformPage extends StatelessWidget {
                 onPressed: () => print('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
                 material: (_, __) => MaterialElevatedButtonData(
-                  icon: Icon(Icons.home),
+                  icon: const Icon(Icons.home),
                 ),
                 cupertino: (_, __) => CupertinoElevatedButtonData(
                   originalStyle: true,
@@ -180,7 +180,7 @@ class PlatformPage extends StatelessWidget {
                 onPressed: () => print('${platform.text} PlatformButton'),
                 padding: const EdgeInsets.all(8),
                 material: (_, __) => MaterialTextButtonData(
-                  icon: Icon(Icons.home),
+                  icon: const Icon(Icons.home),
                 ),
                 cupertino: (_, __) => CupertinoTextButtonData(
                   originalStyle: true,
@@ -351,11 +351,11 @@ class PlatformPage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: PlatformElevatedButton(
-                child: Text('Show Tabbed Pages'),
+                child: const Text('Show Tabbed Pages'),
                 onPressed: () => Navigator.of(context).push(
                   platformPageRoute(
                     context: context,
-                    builder: (context) => TabImplementationPage(),
+                    builder: (context) => const TabImplementationPage(),
                   ),
                 ),
               ),
@@ -365,11 +365,11 @@ class PlatformPage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: PlatformElevatedButton(
-                child: Text('Show  Sliver AppBar Page'),
+                child: const Text('Show  Sliver AppBar Page'),
                 onPressed: () => Navigator.of(context).push(
                   platformPageRoute(
                     context: context,
-                    builder: (context) => PlatformSliverAppBarPage(),
+                    builder: (context) => const PlatformSliverAppBarPage(),
                   ),
                 ),
               ),
@@ -380,11 +380,11 @@ class PlatformPage extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: PlatformElevatedButton(
-                  child: Text('Show Platform Icons'),
+                  child: const Text('Show Platform Icons'),
                   onPressed: () => Navigator.of(context).push(
                     platformPageRoute(
                       context: context,
-                      builder: (context) => IconsPage(),
+                      builder: (context) => const IconsPage(),
                     ),
                   ),
                 ),
@@ -394,11 +394,11 @@ class PlatformPage extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: PlatformElevatedButton(
-                  child: Text('Show Material on iOS'),
+                  child: const Text('Show Material on iOS'),
                   onPressed: () => Navigator.of(context).push(
                     platformPageRoute(
                       context: context,
-                      builder: (context) => IosMaterialPage(),
+                      builder: (context) => const IosMaterialPage(),
                     ),
                   ),
                 ),
@@ -447,7 +447,7 @@ _showExampleDialog(BuildContext context, String text) {
   showPlatformDialog(
     context: context,
     builder: (_) => PlatformAlertDialog(
-      title: Text('Alert'),
+      title: const Text('Alert'),
       content: Text('$text content'),
       actions: <Widget>[
         PlatformDialogAction(

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -12,6 +12,8 @@ import 'sliver_app_bar_page.dart';
 import 'tab_impl_page.dart';
 
 class PlatformPage extends StatelessWidget {
+  const PlatformPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -8,8 +8,8 @@ import 'icons_page.dart';
 import 'logo.dart';
 import 'material_ios_page.dart';
 import 'platform_widget_example.dart';
-import 'tab_impl_page.dart';
 import 'sliver_app_bar_page.dart';
+import 'tab_impl_page.dart';
 
 class PlatformPage extends StatelessWidget {
   @override

--- a/example/lib/platform_page.dart.dart
+++ b/example/lib/platform_page.dart.dart
@@ -431,7 +431,7 @@ ThemeMode _cycleThemeMode(ThemeMode? mode) {
   }
 }
 
-_showDatePicker(BuildContext context) async {
+Future<void> _showDatePicker(BuildContext context) async {
   final now = DateUtils.dateOnly(DateTime.now());
   final date = await showPlatformDatePicker(
     context: context,
@@ -445,7 +445,7 @@ _showDatePicker(BuildContext context) async {
   }
 }
 
-_showExampleDialog(BuildContext context, String text) {
+void _showExampleDialog(BuildContext context, String text) {
   showPlatformDialog(
     context: context,
     builder: (_) => PlatformAlertDialog(
@@ -467,7 +467,7 @@ _showExampleDialog(BuildContext context, String text) {
   );
 }
 
-_showPopupSheet(BuildContext context, String text) {
+void _showPopupSheet(BuildContext context, String text) {
   showPlatformModalSheet(
     context: context,
     builder: (_) => PlatformWidget(

--- a/example/lib/platform_widget_example.dart
+++ b/example/lib/platform_widget_example.dart
@@ -33,7 +33,7 @@ class PlatformWidgetExample extends StatelessWidget {
                     ? TargetPlatform.android
                     : TargetPlatform.iOS),
           ),
-        Divider(
+        const Divider(
           height: 16,
           thickness: 2,
         ),
@@ -51,8 +51,8 @@ class PlatformWidgetExample extends StatelessWidget {
                 child: builder(context, TargetPlatform.android),
               ),
             )).asMaterial(),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
           child: VerticalDivider(
             width: 1,
             thickness: 1,

--- a/example/lib/sliver_app_bar_page.dart
+++ b/example/lib/sliver_app_bar_page.dart
@@ -15,7 +15,7 @@ class _PlatformSliverAppBarPageState extends State<PlatformSliverAppBarPage> {
     return PlatformScaffold(
       body: CustomScrollView(
         slivers: <Widget>[
-          PlatformSliverAppBar(
+          const PlatformSliverAppBar(
             title: Text('Sliver App Bar'),
           ),
           SliverList(
@@ -26,7 +26,7 @@ class _PlatformSliverAppBarPageState extends State<PlatformSliverAppBarPage> {
                   height: 100.0,
                   child: Center(
                     child: PlatformText('$index',
-                        textScaler: TextScaler.linear(5)),
+                        textScaler: const TextScaler.linear(5)),
                   ),
                 );
               },

--- a/example/lib/tab_impl_page.dart
+++ b/example/lib/tab_impl_page.dart
@@ -12,7 +12,7 @@ class TabImplementationPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(
-      appBar: PlatformAppBar(
+      appBar: const PlatformAppBar(
         title: Text('Platform Tab Scaffold'),
       ),
       body: ListView(

--- a/example/lib/tab_impl_page.dart
+++ b/example/lib/tab_impl_page.dart
@@ -69,7 +69,7 @@ class TabImplementationPage extends StatelessWidget {
   }
 }
 
-_openPage(
+void _openPage(
   BuildContext context,
   WidgetBuilder pageToDisplayBuilder,
   TargetPlatform platform,

--- a/example/lib/tab_impl_page.dart
+++ b/example/lib/tab_impl_page.dart
@@ -9,6 +9,8 @@ import 'extensions.dart';
 import 'platform_widget_example.dart';
 
 class TabImplementationPage extends StatelessWidget {
+  const TabImplementationPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(

--- a/example/lib/tab_pages/basicTabbedPage.dart
+++ b/example/lib/tab_pages/basicTabbedPage.dart
@@ -44,12 +44,12 @@ class _BasicTabbedPageState extends State<BasicTabbedPage> {
       ContentView(
         0,
         widget.platform,
-        key: ValueKey('key0'),
+        key: const ValueKey('key0'),
       ),
       ContentView(
         1,
         widget.platform,
-        key: ValueKey('key1'),
+        key: const ValueKey('key1'),
       )
     ];
   }

--- a/example/lib/tab_pages/basicTabbedPage.dart
+++ b/example/lib/tab_pages/basicTabbedPage.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
-import './views/content_view.dart';
 import '../extensions.dart';
+import './views/content_view.dart';
 
 class BasicTabbedPage extends StatefulWidget {
   final TargetPlatform platform;

--- a/example/lib/tab_pages/dynamicTabbedPage.dart
+++ b/example/lib/tab_pages/dynamicTabbedPage.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
-import './views/content_view.dart';
 import '../extensions.dart';
+import './views/content_view.dart';
 
 class DynamicTabbedPage extends StatefulWidget {
   final TargetPlatform platform;

--- a/example/lib/tab_pages/originalTabbedPage.dart
+++ b/example/lib/tab_pages/originalTabbedPage.dart
@@ -43,7 +43,7 @@ class _OriginalTabbedPageState extends State<OriginalTabbedPage> {
   }
 
   void _listener() {
-    print('Current index: ${tabController.index(context)}');
+    debugPrint('Current index: ${tabController.index(context)}');
   }
 
   @override

--- a/example/lib/tab_pages/originalTabbedPage.dart
+++ b/example/lib/tab_pages/originalTabbedPage.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
-import './views/content_view.dart';
 import '../extensions.dart';
+import './views/content_view.dart';
 
 class OriginalTabbedPage extends StatefulWidget {
   final TargetPlatform platform;

--- a/example/lib/tab_pages/views/content_view.dart
+++ b/example/lib/tab_pages/views/content_view.dart
@@ -25,7 +25,7 @@ class _ContentViewState extends State<ContentView> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: PlatformElevatedButton(
-              child: Text('Back'),
+              child: const Text('Back'),
               onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
             ),
           ),
@@ -33,7 +33,7 @@ class _ContentViewState extends State<ContentView> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: PlatformElevatedButton(
-              child: Text('Push to subpage'),
+              child: const Text('Push to subpage'),
               onPressed: () => Navigator.push(
                 context,
                 platformPageRoute(
@@ -51,7 +51,7 @@ class _ContentViewState extends State<ContentView> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: PlatformElevatedButton(
-              child: Text('Increment'),
+              child: const Text('Increment'),
               onPressed: () => setState(() => counter++),
             ),
           ),

--- a/example/lib/tab_pages/views/content_view.dart
+++ b/example/lib/tab_pages/views/content_view.dart
@@ -8,7 +8,7 @@ class ContentView extends StatefulWidget {
   final int index;
   final TargetPlatform platform;
 
-  ContentView(this.index, this.platform, {Key? key}) : super(key: key);
+  const ContentView(this.index, this.platform, {Key? key}) : super(key: key);
 
   @override
   _ContentViewState createState() => _ContentViewState();

--- a/example/lib/tab_pages/views/sliver_view.dart
+++ b/example/lib/tab_pages/views/sliver_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 class SliverView extends StatelessWidget {
-  const SliverView({
+  const SliverView({super.key, 
     required this.title,
     required this.children,
   });

--- a/example/lib/tab_pages/views/sliver_view.dart
+++ b/example/lib/tab_pages/views/sliver_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 class SliverView extends StatelessWidget {
-  SliverView({
+  const SliverView({
     required this.title,
     required this.children,
   });

--- a/example/lib/tab_pages/views/sub_page.dart
+++ b/example/lib/tab_pages/views/sub_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import '../../extensions.dart';
 
 class SubPage extends StatelessWidget {
-  const SubPage(this.tab, this.level, this.platform);
+  const SubPage(this.tab, this.level, this.platform, {super.key});
   final String tab;
   final int level;
   final TargetPlatform platform;

--- a/example/lib/tab_pages/views/sub_page.dart
+++ b/example/lib/tab_pages/views/sub_page.dart
@@ -20,7 +20,7 @@ class SubPage extends StatelessWidget {
         children: [
           Text('Sub Page $tab with $level'),
           PlatformElevatedButton(
-            child: Text('Push to subpage'),
+            child: const Text('Push to subpage'),
             onPressed: () => Navigator.push(
               context,
               platformPageRoute(

--- a/example/lib/tab_pages/views/sub_page.dart
+++ b/example/lib/tab_pages/views/sub_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import '../../extensions.dart';
 
 class SubPage extends StatelessWidget {
-  SubPage(this.tab, this.level, this.platform);
+  const SubPage(this.tab, this.level, this.platform);
   final String tab;
   final int level;
   final TargetPlatform platform;

--- a/lib/flutter_platform_widgets.dart
+++ b/lib/flutter_platform_widgets.dart
@@ -19,17 +19,17 @@ export 'src/platform.dart'
         MaterialDialogData,
         CupertinoDialogData,
         PlatformTarget;
-export 'src/platform_list_tile.dart';
 export 'src/platform_alert_dialog.dart';
 export 'src/platform_app.dart';
 export 'src/platform_app_bar.dart';
-export 'src/platform_circular_progress_indicator.dart';
 export 'src/platform_checkbox.dart';
+export 'src/platform_circular_progress_indicator.dart';
 export 'src/platform_date_picker.dart';
 export 'src/platform_dialog_action.dart';
 export 'src/platform_elevated_button.dart';
 export 'src/platform_icon_button.dart';
 export 'src/platform_icons.dart';
+export 'src/platform_list_tile.dart';
 export 'src/platform_nav_bar.dart';
 export 'src/platform_page.dart';
 export 'src/platform_page_route.dart';
@@ -37,8 +37,8 @@ export 'src/platform_popup_menu.dart';
 export 'src/platform_provider.dart';
 export 'src/platform_radio.dart';
 export 'src/platform_scaffold.dart';
-export 'src/platform_search_bar.dart';
 export 'src/platform_scrollbar.dart';
+export 'src/platform_search_bar.dart';
 export 'src/platform_slider.dart';
 export 'src/platform_sliver_app_bar.dart';
 export 'src/platform_switch.dart';

--- a/lib/src/parent_widget_finder.dart
+++ b/lib/src/parent_widget_finder.dart
@@ -8,7 +8,7 @@ extension WidgetExt on Widget {
 
 /// Simple inherited widget that matches the class of a given type
 class ParentWidgetFinder<T> extends InheritedWidget {
-  ParentWidgetFinder({
+  const ParentWidgetFinder({
     required super.child,
     super.key,
   });

--- a/lib/src/platform_alert_dialog.dart
+++ b/lib/src/platform_alert_dialog.dart
@@ -178,7 +178,7 @@ class PlatformAlertDialog extends PlatformWidgetBase<Widget, AlertDialog> {
       title: data?.title ?? title,
       insetAnimationCurve: curve ?? Curves.decelerate,
       insetAnimationDuration:
-          data?.insetAnimationDuration ?? Duration(milliseconds: 100),
+          data?.insetAnimationDuration ?? const Duration(milliseconds: 100),
     );
 
     // Ensure that there is Material widget at the root page level

--- a/lib/src/platform_alert_dialog.dart
+++ b/lib/src/platform_alert_dialog.dart
@@ -162,7 +162,7 @@ class PlatformAlertDialog extends PlatformWidgetBase<Widget, AlertDialog> {
   Widget createCupertinoWidget(BuildContext context) {
     final data = cupertino?.call(context, platform(context));
 
-    Curve? curve = data?.insetAnimationCurve;
+    final Curve? curve = data?.insetAnimationCurve;
 
     final providerState = PlatformProvider.of(context);
     final useLegacyMaterial =

--- a/lib/src/platform_alert_dialog.dart
+++ b/lib/src/platform_alert_dialog.dart
@@ -113,7 +113,7 @@ class PlatformAlertDialog extends PlatformWidgetBase<Widget, AlertDialog> {
   final PlatformBuilder<MaterialAlertDialogData>? material;
   final PlatformBuilder<CupertinoAlertDialogData>? cupertino;
 
-  PlatformAlertDialog({
+  const PlatformAlertDialog({
     super.key,
     this.widgetKey,
     this.actions,

--- a/lib/src/platform_app.dart
+++ b/lib/src/platform_app.dart
@@ -468,7 +468,7 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
         cupertinoRouter = cupertino;
 
   @override
-  createMaterialWidget(BuildContext context) {
+  MaterialApp createMaterialWidget(BuildContext context) {
     final dataRouter = materialRouter?.call(context, platform(context));
 
     if (routeInformationParser != null ||
@@ -617,7 +617,7 @@ class PlatformApp extends PlatformWidgetBase<CupertinoApp, MaterialApp> {
   }
 
   @override
-  createCupertinoWidget(BuildContext context) {
+  CupertinoApp createCupertinoWidget(BuildContext context) {
     final dataRouter = cupertinoRouter?.call(context, platform(context));
 
     if (routeInformationParser != null ||

--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -16,10 +16,10 @@ import 'platform_provider.dart';
 import 'widget_base.dart';
 
 //the default has alpha which will cause the content to slide under the header for ios
-const Color _kDefaultNavBarBorderColor = const Color(0x4C000000);
+const Color _kDefaultNavBarBorderColor = Color(0x4C000000);
 
-const Border _kDefaultNavBarBorder = const Border(
-  bottom: const BorderSide(
+const Border _kDefaultNavBarBorder = Border(
+  bottom: BorderSide(
     color: _kDefaultNavBarBorderColor,
     width: 0.0, // One physical pixel.
     style: BorderStyle.solid,

--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -216,7 +216,7 @@ class PlatformAppBar
   CupertinoNavigationBar createCupertinoWidget(BuildContext context) {
     final data = cupertino?.call(context, platform(context));
 
-    var trailing = trailingActions?.isEmpty ?? true
+    final trailing = trailingActions?.isEmpty ?? true
         ? null
         : Row(
             mainAxisSize: MainAxisSize.min,

--- a/lib/src/platform_app_bar.dart
+++ b/lib/src/platform_app_bar.dart
@@ -158,7 +158,7 @@ class PlatformAppBar
   final PlatformBuilder<MaterialAppBarData>? material;
   final PlatformBuilder<CupertinoNavigationBarData>? cupertino;
 
-  PlatformAppBar({
+  const PlatformAppBar({
     super.key,
     this.widgetKey,
     this.title,

--- a/lib/src/platform_checkbox.dart
+++ b/lib/src/platform_checkbox.dart
@@ -121,7 +121,7 @@ class PlatformCheckbox extends PlatformWidgetBase<CupertinoCheckbox, Checkbox> {
   final PlatformBuilder<MaterialCheckboxData>? material;
   final PlatformBuilder<CupertinoCheckboxData>? cupertino;
 
-  PlatformCheckbox({
+  const PlatformCheckbox({
     required this.onChanged,
     //Common
     super.key,

--- a/lib/src/platform_circular_progress_indicator.dart
+++ b/lib/src/platform_circular_progress_indicator.dart
@@ -72,7 +72,7 @@ class PlatformCircularProgressIndicator extends PlatformWidgetBase<
   final PlatformBuilder<MaterialProgressIndicatorData>? material;
   final PlatformBuilder<CupertinoProgressIndicatorData>? cupertino;
 
-  PlatformCircularProgressIndicator({
+  const PlatformCircularProgressIndicator({
     super.key,
     this.widgetKey,
     this.material,

--- a/lib/src/platform_dialog_action.dart
+++ b/lib/src/platform_dialog_action.dart
@@ -138,7 +138,7 @@ class PlatformDialogAction
 
   final PlatformBuilder<CupertinoDialogActionData>? cupertino;
 
-  PlatformDialogAction({
+  const PlatformDialogAction({
     super.key,
     this.widgetKey,
     this.child,

--- a/lib/src/platform_elevated_button.dart
+++ b/lib/src/platform_elevated_button.dart
@@ -110,7 +110,7 @@ class PlatformElevatedButton
   final PlatformBuilder<CupertinoElevatedButtonData>? cupertino;
   final PlatformBuilder<MaterialElevatedButtonData>? material;
 
-  PlatformElevatedButton({
+  const PlatformElevatedButton({
     super.key,
     this.widgetKey,
     this.onPressed,

--- a/lib/src/platform_elevated_button.dart
+++ b/lib/src/platform_elevated_button.dart
@@ -181,7 +181,7 @@ class PlatformElevatedButton
         child: data?.child ?? child!,
         onPressed: data?.onPressed ?? onPressed,
         borderRadius: data?.borderRadius ??
-            const BorderRadius.all(const Radius.circular(8.0)),
+            const BorderRadius.all(Radius.circular(8.0)),
         minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
         padding: data?.padding ?? padding,
         pressedOpacity: data?.pressedOpacity ?? 0.4,
@@ -202,7 +202,7 @@ class PlatformElevatedButton
         child: data?.child ?? child!,
         onPressed: data?.onPressed ?? onPressed,
         borderRadius: data?.borderRadius ??
-            const BorderRadius.all(const Radius.circular(8.0)),
+            const BorderRadius.all(Radius.circular(8.0)),
         minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
         padding: data?.padding ?? padding,
         pressedOpacity: data?.pressedOpacity ?? 0.4,

--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -213,7 +213,7 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
       padding: givenPadding,
       color: data?.color ?? color,
       borderRadius: data?.borderRadius ??
-          const BorderRadius.all(const Radius.circular(8.0)),
+          const BorderRadius.all(Radius.circular(8.0)),
       minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
       pressedOpacity: data?.pressedOpacity ?? 0.4,
       disabledColor: data?.disabledColor ??

--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -161,7 +161,7 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
     return IconButton(
       key: data?.widgetKey ?? widgetKey,
       icon: data?.icon ?? materialIcon ?? icon!,
-      onPressed: data?.onPressed ?? onPressed ?? null,
+      onPressed: data?.onPressed ?? onPressed,
       padding: data?.padding ?? padding ?? const EdgeInsets.all(8.0),
       color: data?.color ?? color,
       alignment: data?.alignment ?? Alignment.center,
@@ -209,7 +209,7 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
     return CupertinoButton(
       key: data?.widgetKey ?? widgetKey,
       child: data?.icon ?? cupertinoIcon ?? icon!,
-      onPressed: data?.onPressed ?? onPressed ?? null,
+      onPressed: data?.onPressed ?? onPressed,
       padding: givenPadding,
       color: data?.color ?? color,
       borderRadius: data?.borderRadius ??

--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -16,8 +16,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_platform_widgets/src/parent_widget_finder.dart';
 
 import 'platform.dart';
-import 'widget_base.dart';
 import 'platform_provider.dart';
+import 'widget_base.dart';
 
 const double _kMinInteractiveDimensionCupertino = 44.0;
 

--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -136,7 +136,7 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
   final PlatformBuilder<MaterialIconButtonData>? material;
   final PlatformBuilder<CupertinoIconButtonData>? cupertino;
 
-  PlatformIconButton({
+  const PlatformIconButton({
     super.key,
     this.widgetKey,
     this.icon,

--- a/lib/src/platform_list_tile.dart
+++ b/lib/src/platform_list_tile.dart
@@ -141,7 +141,7 @@ class PlatformListTile extends PlatformWidgetBase<CupertinoListTile, ListTile> {
   final PlatformBuilder<MaterialListTileData>? material;
   final PlatformBuilder<CupertinoListTileData>? cupertino;
 
-  PlatformListTile({
+  const PlatformListTile({
     required this.title,
     this.leading,
     this.subtitle,

--- a/lib/src/platform_nav_bar.dart
+++ b/lib/src/platform_nav_bar.dart
@@ -240,7 +240,7 @@ class PlatformNavBar extends PlatformWidgetBase<CupertinoTabBar, Widget> {
   Widget _createMaterial2Widget(BuildContext context) {
     final data = material?.call(context, platform(context));
 
-    var bar = BottomNavigationBar(
+    final bar = BottomNavigationBar(
       items: data?.items ?? items ?? const <BottomNavigationBarItem>[],
       currentIndex: data?.currentIndex ?? currentIndex ?? 0,
       onTap: data?.itemChanged ?? itemChanged,

--- a/lib/src/platform_nav_bar.dart
+++ b/lib/src/platform_nav_bar.dart
@@ -176,7 +176,7 @@ class PlatformNavBar extends PlatformWidgetBase<CupertinoTabBar, Widget> {
   final PlatformBuilder<MaterialNavigationBarData>? material3;
   final PlatformBuilder<CupertinoTabBarData>? cupertino;
 
-  PlatformNavBar({
+  const PlatformNavBar({
     super.key,
     this.widgetKey,
     this.backgroundColor,

--- a/lib/src/platform_popup_menu.dart
+++ b/lib/src/platform_popup_menu.dart
@@ -243,7 +243,7 @@ class PlatformPopupMenu extends StatelessWidget {
                 key: data?.key,
                 isDefaultAction: data?.isDefaultAction ?? false,
                 isDestructiveAction: data?.isDestructiveAction ?? false,
-                child: data?.child ?? Text(option.label ?? ""),
+                child: data?.child ?? Text(option.label ?? ''),
                 onPressed: data?.onPressed ??
                     () {
                       Navigator.pop(context);
@@ -281,7 +281,7 @@ class PlatformPopupMenu extends StatelessWidget {
               final data = option.material?.call(context, platform(context));
               items.add(PopupMenuItem<PopupMenuOption>(
                 value: option,
-                child: data?.child ?? Text(option.label ?? ""),
+                child: data?.child ?? Text(option.label ?? ''),
                 enabled: data?.enabled ?? true,
                 height: data?.height ?? kMinInteractiveDimension,
                 key: data?.key,

--- a/lib/src/platform_provider.dart
+++ b/lib/src/platform_provider.dart
@@ -34,7 +34,7 @@ class PlatformProvider extends StatefulWidget {
   final PlatformSettingsData? settings;
 
   static PlatformProviderState? of(BuildContext context) {
-    _PlatformProviderState? state =
+    final _PlatformProviderState? state =
         context.findAncestorStateOfType<_PlatformProviderState>();
 
     return state?.state;

--- a/lib/src/platform_radio.dart
+++ b/lib/src/platform_radio.dart
@@ -108,7 +108,7 @@ class PlatformRadio<T> extends PlatformWidgetBase<CupertinoRadio, Radio> {
   final PlatformBuilder<MaterialRadioData>? material;
   final PlatformBuilder<CupertinoRadioData>? cupertino;
 
-  PlatformRadio({
+  const PlatformRadio({
     super.key,
     this.widgetKey,
     this.value,

--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -186,7 +186,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
   Widget createCupertinoWidget(BuildContext context) {
     final data = cupertino?.call(context, platform(context));
 
-    var navigationBar =
+    final navigationBar =
         data?.navigationBar ?? appBar?.createCupertinoWidget(context);
 
     final providerState = PlatformProvider.of(context);
@@ -196,7 +196,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
 
     Widget result;
     if (bottomNavBar != null) {
-      var tabBar =
+      final tabBar =
           data?.bottomTabBar ?? bottomNavBar?.createCupertinoWidget(context);
 
       //https://docs.flutter.io/flutter/cupertino/CupertinoTabScaffold-class.html
@@ -207,7 +207,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
         tabBar: tabBar!,
         controller: data?.controller,
         tabBuilder: (BuildContext context, int index) {
-          var currentChild = cupertinoTabChildBuilder?.call(context, index) ??
+          final currentChild = cupertinoTabChildBuilder?.call(context, index) ??
               data?.body ??
               body ??
               const SizedBox.shrink();

--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -131,7 +131,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
   final bool iosContentPadding;
   final bool iosContentBottomPadding;
 
-  PlatformScaffold({
+  const PlatformScaffold({
     super.key,
     this.widgetKey,
     this.body,

--- a/lib/src/platform_scaffold.dart
+++ b/lib/src/platform_scaffold.dart
@@ -210,7 +210,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
           var currentChild = cupertinoTabChildBuilder?.call(context, index) ??
               data?.body ??
               body ??
-              SizedBox.shrink();
+              const SizedBox.shrink();
           return CupertinoPageScaffold(
             // key
             backgroundColor: data?.backgroundColor ?? backgroundColor,
@@ -228,7 +228,7 @@ class PlatformScaffold extends PlatformWidgetBase<Widget, Scaffold> {
         restorationId: data?.restorationIdTab,
       );
     } else {
-      final child = data?.body ?? body ?? SizedBox.shrink();
+      final child = data?.body ?? body ?? const SizedBox.shrink();
 
       result = CupertinoPageScaffold(
         key: data?.widgetKey ?? widgetKey,

--- a/lib/src/platform_scrollbar.dart
+++ b/lib/src/platform_scrollbar.dart
@@ -96,7 +96,7 @@ class PlatformScrollbar
   final PlatformBuilder<MaterialScrollbarData>? material;
   final PlatformBuilder<CupertinoScrollbarData>? cupertino;
 
-  PlatformScrollbar({
+  const PlatformScrollbar({
     //Common
     super.key,
     this.widgetKey,

--- a/lib/src/platform_search_bar.dart
+++ b/lib/src/platform_search_bar.dart
@@ -200,7 +200,7 @@ class PlatformSearchBar
   final PlatformBuilder<MaterialSearchBarData>? material;
   final PlatformBuilder<CupertinoSearchBarData>? cupertino;
 
-  PlatformSearchBar({
+  const PlatformSearchBar({
     //Common
     super.key,
     this.widgetKey,

--- a/lib/src/platform_slider.dart
+++ b/lib/src/platform_slider.dart
@@ -107,7 +107,7 @@ class PlatformSlider extends PlatformWidgetBase<CupertinoSlider, Slider> {
   final PlatformBuilder<MaterialSliderData>? material;
   final PlatformBuilder<CupertinoSliderData>? cupertino;
 
-  PlatformSlider({
+  const PlatformSlider({
     super.key,
     this.widgetKey,
     required this.value,

--- a/lib/src/platform_sliver_app_bar.dart
+++ b/lib/src/platform_sliver_app_bar.dart
@@ -6,10 +6,11 @@
 
 import 'package:flutter/cupertino.dart'
     show CupertinoSliverNavigationBar, NavigationBarBottomMode;
-import 'package:flutter/material.dart' show SliverAppBar, kToolbarHeight;
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart' show AsyncCallback, Brightness;
+import 'package:flutter/material.dart' show SliverAppBar, kToolbarHeight;
 import 'package:flutter/services.dart' show SystemUiOverlayStyle;
+import 'package:flutter/widgets.dart';
+
 import 'platform.dart';
 import 'widget_base.dart';
 

--- a/lib/src/platform_sliver_app_bar.dart
+++ b/lib/src/platform_sliver_app_bar.dart
@@ -181,7 +181,7 @@ class PlatformSliverAppBar
   final PlatformBuilder<MaterialSliverAppBarData>? material;
   final PlatformBuilder<CupertinoSliverAppBarData>? cupertino;
 
-  PlatformSliverAppBar({
+  const PlatformSliverAppBar({
     //Common
     super.key,
     this.widgetKey,

--- a/lib/src/platform_switch.dart
+++ b/lib/src/platform_switch.dart
@@ -156,7 +156,7 @@ class PlatformSwitch extends PlatformWidgetBase<CupertinoSwitch, Switch> {
   final PlatformBuilder<MaterialSwitchData>? material;
   final PlatformBuilder<CupertinoSwitchData>? cupertino;
 
-  PlatformSwitch({
+  const PlatformSwitch({
     super.key,
     this.widgetKey,
     required this.value,

--- a/lib/src/platform_tab_scaffold.dart
+++ b/lib/src/platform_tab_scaffold.dart
@@ -184,7 +184,7 @@ class PlatformTabScaffold extends PlatformWidgetBase<Widget, Widget> {
   final String? restorationId;
   final double? navBarHeight;
 
-  PlatformTabScaffold({
+  const PlatformTabScaffold({
     super.key,
     this.widgetKey,
     this.items,

--- a/lib/src/platform_text.dart
+++ b/lib/src/platform_text.dart
@@ -32,7 +32,7 @@ String formatData(BuildContext context, String data) {
   return data;
 }
 
-typedef Text _TextBuilder(BuildContext context);
+typedef _TextBuilder = Text Function(BuildContext context);
 
 class PlatformText extends StatelessWidget {
   final _TextBuilder _textBuilder;

--- a/lib/src/platform_text.dart
+++ b/lib/src/platform_text.dart
@@ -37,7 +37,7 @@ typedef Text _TextBuilder(BuildContext context);
 class PlatformText extends StatelessWidget {
   final _TextBuilder _textBuilder;
 
-  PlatformText._(Key? key, this._textBuilder) : super(key: key);
+  const PlatformText._(Key? key, this._textBuilder) : super(key: key);
 
   factory PlatformText(
     String data, {

--- a/lib/src/platform_text_button.dart
+++ b/lib/src/platform_text_button.dart
@@ -110,7 +110,7 @@ class PlatformTextButton extends PlatformWidgetBase<Widget, TextButton> {
   final PlatformBuilder<CupertinoTextButtonData>? cupertino;
   final PlatformBuilder<MaterialTextButtonData>? material;
 
-  PlatformTextButton({
+  const PlatformTextButton({
     super.key,
     this.widgetKey,
     this.onPressed,

--- a/lib/src/platform_text_button.dart
+++ b/lib/src/platform_text_button.dart
@@ -182,7 +182,7 @@ class PlatformTextButton extends PlatformWidgetBase<Widget, TextButton> {
         child: data?.child ?? child!,
         onPressed: data?.onPressed ?? onPressed,
         borderRadius: data?.borderRadius ??
-            const BorderRadius.all(const Radius.circular(8.0)),
+            const BorderRadius.all(Radius.circular(8.0)),
         minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
         padding: data?.padding ?? padding,
         pressedOpacity: data?.pressedOpacity ?? 0.4,
@@ -210,7 +210,7 @@ class PlatformTextButton extends PlatformWidgetBase<Widget, TextButton> {
         child: data?.child ?? child!,
         onPressed: data?.onPressed ?? onPressed,
         borderRadius: data?.borderRadius ??
-            const BorderRadius.all(const Radius.circular(8.0)),
+            const BorderRadius.all(Radius.circular(8.0)),
         minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
         padding: data?.padding ?? padding,
         pressedOpacity: data?.pressedOpacity ?? 0.4,

--- a/lib/src/platform_text_field.dart
+++ b/lib/src/platform_text_field.dart
@@ -427,7 +427,7 @@ class PlatformTextField
     );
   }
 
-  PlatformTextField({
+  const PlatformTextField({
     super.key,
     this.widgetKey,
     this.controller,

--- a/lib/src/platform_text_form_field.dart
+++ b/lib/src/platform_text_form_field.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
+
 import 'package:flutter/cupertino.dart'
     show
         CupertinoAdaptiveTextSelectionToolbar,
@@ -12,7 +14,6 @@ import 'package:flutter/material.dart'
         TextFormField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
 import 'platform.dart';
 import 'widget_base.dart';

--- a/lib/src/platform_theme.dart
+++ b/lib/src/platform_theme.dart
@@ -29,7 +29,7 @@ class PlatformTheme extends StatefulWidget {
   });
 
   static PlatformThemeState? of(BuildContext context) {
-    _PlatformThemeState? state =
+    final _PlatformThemeState? state =
         context.findAncestorStateOfType<_PlatformThemeState>();
 
     return state?.state;

--- a/lib/src/platform_widget.dart
+++ b/lib/src/platform_widget.dart
@@ -13,7 +13,7 @@ class PlatformWidget extends PlatformWidgetBase<Widget, Widget> {
   final PlatformBuilder<Widget?>? material;
   final PlatformBuilder<Widget?>? cupertino;
 
-  PlatformWidget({
+  const PlatformWidget({
     super.key,
     this.cupertino,
     this.material,

--- a/lib/src/platform_widget.dart
+++ b/lib/src/platform_widget.dart
@@ -21,11 +21,11 @@ class PlatformWidget extends PlatformWidgetBase<Widget, Widget> {
 
   @override
   Widget createMaterialWidget(BuildContext context) {
-    return material?.call(context, platform(context)) ?? SizedBox.shrink();
+    return material?.call(context, platform(context)) ?? const SizedBox.shrink();
   }
 
   @override
   Widget createCupertinoWidget(BuildContext context) {
-    return cupertino?.call(context, platform(context)) ?? SizedBox.shrink();
+    return cupertino?.call(context, platform(context)) ?? const SizedBox.shrink();
   }
 }

--- a/lib/src/platform_widget_builder.dart
+++ b/lib/src/platform_widget_builder.dart
@@ -19,7 +19,7 @@ class PlatformWidgetBuilder extends StatelessWidget {
   final Widget? Function(BuildContext, Widget?, PlatformTarget)? cupertino;
   final Widget? Function(BuildContext, Widget?, PlatformTarget)? material;
 
-  PlatformWidgetBuilder({
+  const PlatformWidgetBuilder({
     super.key,
     this.cupertino,
     this.material,

--- a/lib/src/widget_base.dart
+++ b/lib/src/widget_base.dart
@@ -9,8 +9,8 @@ import 'package:flutter/widgets.dart';
 
 import 'platform.dart';
 
-typedef T PlatformBuilder<T>(BuildContext context, PlatformTarget platform);
-typedef T PlatformIndexBuilder<T>(
+typedef PlatformBuilder<T> = T Function(BuildContext context, PlatformTarget platform);
+typedef PlatformIndexBuilder<T> = T Function(
     BuildContext context, PlatformTarget platform, int index);
 
 abstract class PlatformWidgetBase<I extends Widget, A extends Widget>

--- a/lib/src/widget_base.dart
+++ b/lib/src/widget_base.dart
@@ -25,7 +25,7 @@ abstract class PlatformWidgetBase<I extends Widget, A extends Widget>
       return createCupertinoWidget(context);
     }
 
-    return throw new UnsupportedError(
+    return throw UnsupportedError(
         'This platform is not supported: $defaultTargetPlatform');
   }
 


### PR DESCRIPTION
The following is list of lints that were used for cleanup, using the `dart fix --apply --code=...` command one-by-one. I tried to use the most base lints, to include any opinionations. But incase any are still too opinionated, they can be reverted at the the commit leave.

Some give 'free-performance' by just using `const` wherever applicable. Other add some type-safety.