### PR TITLE
fix: Remove default for minSize in platform_icon_button

### DIFF
--- a/lib/src/platform_icon_button.dart
+++ b/lib/src/platform_icon_button.dart
@@ -225,7 +225,7 @@ class PlatformIconButton extends PlatformWidgetBase<CupertinoButton, Widget> {
       borderRadius:
           data?.borderRadius ??
           const BorderRadius.all(const Radius.circular(8.0)),
-      minSize: data?.minSize ?? _kMinInteractiveDimensionCupertino,
+      minSize: data?.minSize,
       pressedOpacity: data?.pressedOpacity ?? 0.4,
       disabledColor:
           data?.disabledColor ??


### PR DESCRIPTION
Since minSize is deprecated it's no longer necessary to add a default for this. The default has to be removed anyway, otherwise the new value `minimumSize` cannot be set. There is an assert in the CupertinoButton that only allows one of the two values.

The assert:

`assert(minimumSize == null || minSize == null)`

Without my changes, there is an exception if we try to use minimumSize.

Example:

```dart
PlatformIconButton(
      icon: const Icon(Icons.sort),
      cupertino: (_, _) => CupertinoIconButtonData(minimumSize: Size.square(34)),
    );
```